### PR TITLE
Add gemologist GUI with gem crushing and mine shop command

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ database:
 |---------|------------|-------------|
 | `/crafting` | mycraftingplugin.use | Opens the main crafting menu |
 | `/editcrafting` | mycraftingplugin.editlayout | Opens the crafting menu in edit mode |
+| `/mine_shop` | mycraftingplugin.use | Opens the mine shop menu |
+| `/edit_mine_shop` | mycraftingplugin.editlayout | Opens the mine shop menu in edit mode |
 | `/alchemy` | mycraftingplugin.use | Opens the alchemy menu |
 | `/edit_alchemy` | mycraftingplugin.editlayout | Opens the alchemy menu in edit mode |
 | `/jeweler` or `/jew` | mycraftingplugin.use | Opens the jeweler menu |

--- a/src/main/java/com/maks/mycraftingplugin2/EditGemologistCommand.java
+++ b/src/main/java/com/maks/mycraftingplugin2/EditGemologistCommand.java
@@ -1,0 +1,31 @@
+package com.maks.mycraftingplugin2;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+/**
+ * /edit_gemologist - Opens the gemologist menu in edit mode.
+ */
+public class EditGemologistCommand implements CommandExecutor {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command.");
+            return true;
+        }
+
+        Player player = (Player) sender;
+
+        if (!player.hasPermission("mycraftingplugin.editlayout")) {
+            player.sendMessage(ChatColor.RED + "You don't have permission to edit the gemologist layout.");
+            return true;
+        }
+
+        GemologistMainMenu.openEditor(player);
+        return true;
+    }
+}

--- a/src/main/java/com/maks/mycraftingplugin2/EditMineShopCommand.java
+++ b/src/main/java/com/maks/mycraftingplugin2/EditMineShopCommand.java
@@ -1,0 +1,31 @@
+package com.maks.mycraftingplugin2;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+/**
+ * /edit_mine_shop - Opens the mine shop crafting menu in edit mode.
+ */
+public class EditMineShopCommand implements CommandExecutor {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command.");
+            return true;
+        }
+
+        Player player = (Player) sender;
+
+        if (!player.hasPermission("mycraftingplugin.editlayout")) {
+            player.sendMessage(ChatColor.RED + "You don't have permission to edit the mine shop layout.");
+            return true;
+        }
+
+        MainMenu.openEditor(player);
+        return true;
+    }
+}

--- a/src/main/java/com/maks/mycraftingplugin2/GemCrushingCommand.java
+++ b/src/main/java/com/maks/mycraftingplugin2/GemCrushingCommand.java
@@ -1,0 +1,35 @@
+package com.maks.mycraftingplugin2;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+/**
+ * /gem_crushing - Opens the gem crushing menu directly.
+ */
+public class GemCrushingCommand implements CommandExecutor {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command.");
+            return true;
+        }
+
+        Player player = (Player) sender;
+        GemCrushingMenu.open(player);
+        return true;
+    }
+
+    /**
+     * Opens the gem crushing menu directly, bypassing permission checks.
+     * This should only be called from within the plugin, not from external commands.
+     *
+     * @param player The player to open the menu for
+     */
+    public static void openMenuWithoutPermissionCheck(Player player) {
+        GemCrushingMenu.open(player);
+    }
+}

--- a/src/main/java/com/maks/mycraftingplugin2/GemCrushingMenu.java
+++ b/src/main/java/com/maks/mycraftingplugin2/GemCrushingMenu.java
@@ -1,0 +1,177 @@
+package com.maks.mycraftingplugin2;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Menu for crushing gems into Shiny Dust.
+ */
+public class GemCrushingMenu {
+
+    private static final List<String> GEM_NAMES = List.of(
+            "Ruby",
+            "Amethyst",
+            "Cyianite",
+            "Zircon",
+            "Diamond",
+            "Rhodolite",
+            "Onyx"
+    );
+
+    public static void open(Player player) {
+        Inventory inv = Bukkit.createInventory(null, 27, "Gem Crushing");
+
+        for (int i = 0; i < inv.getSize(); i++) {
+            if (i < 18) {
+                continue;
+            } else if (i == 22) {
+                ItemStack confirmButton = new ItemStack(Material.EMERALD);
+                ItemMeta meta = confirmButton.getItemMeta();
+                if (meta != null) {
+                    meta.setDisplayName(ChatColor.GREEN + "Confirm Crushing");
+                    List<String> lore = new ArrayList<>();
+                    lore.add(ChatColor.GRAY + "Click to crush all gems");
+                    lore.add(ChatColor.GRAY + "and receive Shiny Dust");
+                    meta.setLore(lore);
+                    confirmButton.setItemMeta(meta);
+                }
+                inv.setItem(i, confirmButton);
+            } else {
+                ItemStack glass = new ItemStack(Material.BLACK_STAINED_GLASS_PANE);
+                ItemMeta meta = glass.getItemMeta();
+                if (meta != null) {
+                    meta.setDisplayName(" ");
+                    glass.setItemMeta(meta);
+                }
+                inv.setItem(i, glass);
+            }
+        }
+
+        player.openInventory(inv);
+    }
+
+    public static boolean isGem(ItemStack item) {
+        if (item == null || !item.hasItemMeta() || !item.getItemMeta().hasDisplayName()) {
+            return false;
+        }
+
+        ItemMeta meta = item.getItemMeta();
+        String displayName = ChatColor.stripColor(meta.getDisplayName());
+
+        boolean hasTier = displayName.contains("[ I ]") || displayName.contains("[ II ]") || displayName.contains("[ III ]");
+        if (!hasTier) {
+            return false;
+        }
+
+        boolean isKnownGem = false;
+        for (String name : GEM_NAMES) {
+            if (displayName.contains(name)) {
+                isKnownGem = true;
+                break;
+            }
+        }
+        if (!isKnownGem) {
+            return false;
+        }
+
+        return meta.hasEnchant(Enchantment.DURABILITY);
+    }
+
+    public static int getGemTier(ItemStack item) {
+        if (item == null || !item.hasItemMeta() || !item.getItemMeta().hasDisplayName()) {
+            return 0;
+        }
+        String displayName = item.getItemMeta().getDisplayName();
+        if (displayName.contains("[ I ]")) {
+            return 1;
+        } else if (displayName.contains("[ II ]")) {
+            return 2;
+        } else if (displayName.contains("[ III ]")) {
+            return 3;
+        }
+        return 0;
+    }
+
+    public static void processGems(Player player, Inventory inv) {
+        int totalDust = 0;
+        List<Integer> slotsToEmpty = new ArrayList<>();
+
+        for (int i = 0; i < 18; i++) {
+            ItemStack item = inv.getItem(i);
+            if (item != null && isGem(item)) {
+                int tier = getGemTier(item);
+                int amount = item.getAmount();
+                if (tier > 0) {
+                    totalDust += tier * amount;
+                    slotsToEmpty.add(i);
+                }
+            }
+        }
+
+        if (totalDust > 0) {
+            ItemStack dust = createShinyDust(totalDust);
+            if (player.getInventory().firstEmpty() != -1) {
+                player.getInventory().addItem(dust);
+                for (int slot : slotsToEmpty) {
+                    inv.setItem(slot, null);
+                }
+                player.sendMessage(ChatColor.GREEN + "You crushed gems and received " + totalDust + " Shiny Dust!");
+            } else {
+                player.sendMessage(ChatColor.RED + "Your inventory is full! Make space before crushing gems.");
+            }
+        } else {
+            player.sendMessage(ChatColor.RED + "No valid gems to crush!");
+        }
+    }
+
+    public static void returnItemsToPlayer(Player player, Inventory inv) {
+        List<ItemStack> itemsToReturn = new ArrayList<>();
+        for (int i = 0; i < 18; i++) {
+            ItemStack item = inv.getItem(i);
+            if (item != null && item.getType() != Material.AIR) {
+                itemsToReturn.add(item.clone());
+                inv.setItem(i, null);
+            }
+        }
+
+        for (ItemStack item : itemsToReturn) {
+            player.getInventory().addItem(item);
+        }
+    }
+
+    private static ItemStack createShinyDust(int amount) {
+        try {
+            Class<?> itemManagerClass = Class.forName("com.maks.trinketsplugin.ItemManager");
+            java.lang.reflect.Method getItemMethod = itemManagerClass.getMethod("getItem", String.class, int.class);
+            Object result = getItemMethod.invoke(null, "shiny_dust", amount);
+            if (result instanceof ItemStack) {
+                return (ItemStack) result;
+            }
+        } catch (Exception ignored) {
+        }
+
+        ItemStack dust = new ItemStack(Material.GLOW_INK_SAC, amount);
+        ItemMeta meta = dust.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName("§5Shiny Dust");
+            List<String> lore = new ArrayList<>();
+            lore.add("§7§oUsed to upgrade gems");
+            meta.setLore(lore);
+            meta.addEnchant(Enchantment.DURABILITY, 10, true);
+            meta.addItemFlags(ItemFlag.HIDE_ENCHANTS, ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_UNBREAKABLE);
+            meta.setUnbreakable(true);
+            dust.setItemMeta(meta);
+        }
+        return dust;
+    }
+}

--- a/src/main/java/com/maks/mycraftingplugin2/GemologistCommand.java
+++ b/src/main/java/com/maks/mycraftingplugin2/GemologistCommand.java
@@ -1,0 +1,25 @@
+package com.maks.mycraftingplugin2;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+/**
+ * /gemologist - Opens the gemologist menu (normal GUI for browsing).
+ */
+public class GemologistCommand implements CommandExecutor {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command.");
+            return true;
+        }
+
+        Player player = (Player) sender;
+        GemologistMainMenu.open(player);
+        return true;
+    }
+}

--- a/src/main/java/com/maks/mycraftingplugin2/GemologistMainMenu.java
+++ b/src/main/java/com/maks/mycraftingplugin2/GemologistMainMenu.java
@@ -1,0 +1,61 @@
+package com.maks.mycraftingplugin2;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+/**
+ * Main menu for the Gemologist (normal and edit mode).
+ */
+public class GemologistMainMenu {
+
+    public static void open(Player player) {
+        Inventory inv = Bukkit.createInventory(null, 27, "Gemologist Menu");
+
+        inv.setItem(11, createMenuItem(Material.CRAFTING_TABLE, ChatColor.GREEN + "Gem Crafting"));
+        inv.setItem(13, createMenuItem(Material.AMETHYST_SHARD, ChatColor.GREEN + "Gem Actions"));
+        inv.setItem(15, createMenuItem(Material.GRINDSTONE, ChatColor.GREEN + "Gem Crushing"));
+
+        fillWithGlass(inv);
+        player.openInventory(inv);
+    }
+
+    public static void openEditor(Player player) {
+        Inventory inv = Bukkit.createInventory(null, 27, "Edit Gemologist Menu");
+
+        inv.setItem(11, createMenuItem(Material.CRAFTING_TABLE, ChatColor.GREEN + "Gem Crafting"));
+        inv.setItem(13, createMenuItem(Material.AMETHYST_SHARD, ChatColor.GREEN + "Gem Actions"));
+        inv.setItem(15, createMenuItem(Material.GRINDSTONE, ChatColor.GREEN + "Gem Crushing"));
+
+        fillWithGlass(inv);
+        player.openInventory(inv);
+    }
+
+    private static ItemStack createMenuItem(Material material, String name) {
+        ItemStack item = new ItemStack(material);
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(name);
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    private static void fillWithGlass(Inventory inv) {
+        ItemStack glass = new ItemStack(Material.BLACK_STAINED_GLASS_PANE);
+        ItemMeta meta = glass.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(" ");
+            glass.setItemMeta(meta);
+        }
+        for (int i = 0; i < inv.getSize(); i++) {
+            if (inv.getItem(i) == null) {
+                inv.setItem(i, glass);
+            }
+        }
+    }
+}

--- a/src/main/java/com/maks/mycraftingplugin2/Main.java
+++ b/src/main/java/com/maks/mycraftingplugin2/Main.java
@@ -37,11 +37,16 @@ public class Main extends JavaPlugin {
         // Rejestracja komend
         getCommand("crafting").setExecutor(new CraftingCommand());
         getCommand("editcrafting").setExecutor(new EditCraftingCommand());
+        getCommand("mine_shop").setExecutor(new MineShopCommand());
+        getCommand("edit_mine_shop").setExecutor(new EditMineShopCommand());
         getCommand("alchemy").setExecutor(new AlchemyCommand());
         getCommand("edit_alchemy").setExecutor(new EditAlchemyCommand());
         getCommand("jeweler").setExecutor(new JewelerCommand());
         getCommand("edit_jeweler").setExecutor(new EditJewelerCommand());
         getCommand("jewels_crushing").setExecutor(new JewelsCrushingCommand());
+        getCommand("gemologist").setExecutor(new GemologistCommand());
+        getCommand("edit_gemologist").setExecutor(new EditGemologistCommand());
+        getCommand("gem_crushing").setExecutor(new GemCrushingCommand());
         getCommand("emilia").setExecutor(new EmiliaCommand());
         getCommand("edit_emilia").setExecutor(new EditEmiliaCommand());
         getCommand("zumpe").setExecutor(new ZumpeCommand());

--- a/src/main/java/com/maks/mycraftingplugin2/MenuListener.java
+++ b/src/main/java/com/maks/mycraftingplugin2/MenuListener.java
@@ -45,6 +45,14 @@ public class MenuListener implements Listener {
             // Return all items from crushing slots to player
             JewelsCrushingMenu.returnItemsToPlayer(player, event.getInventory());
         }
+        // Handle Gem Crushing menu closure
+        else if (title.equals("Gem Crushing")) {
+            if (debuggingFlag == 1) {
+                Bukkit.getLogger().info("[MenuListener] Handling Gem Crushing menu close for: " + player.getName());
+            }
+
+            GemCrushingMenu.returnItemsToPlayer(player, event.getInventory());
+        }
 
         // Handle other menus that might need item protection
         else if (title.equals("Add New Recipe") || title.equals("Edit Recipe")) {
@@ -136,6 +144,12 @@ public class MenuListener implements Listener {
             handleEditJewelerMenuClick(player, itemName);
         } else if (title.equals("Jewels Crushing")) {
             handleJewelsCrushingMenuClick(event, player, clickedItem, itemName);
+        } else if (title.equals("Gemologist Menu")) {
+            handleGemologistMenuClick(player, itemName);
+        } else if (title.equals("Edit Gemologist Menu")) {
+            handleEditGemologistMenuClick(player, itemName);
+        } else if (title.equals("Gem Crushing")) {
+            handleGemCrushingMenuClick(event, player, clickedItem, itemName);
         } else if (title.equals("Emilia Shop")) {
             handleEmiliaMainMenu(player, clickedItem, itemName);
         } else if (title.equals("Edit Emilia Shop")) {
@@ -186,6 +200,9 @@ public class MenuListener implements Listener {
                 || title.equals("Jeweler Menu")
                 || title.equals("Edit Jeweler Menu")
                 || title.equals("Jewels Crushing")
+                || title.equals("Gemologist Menu")
+                || title.equals("Edit Gemologist Menu")
+                || title.equals("Gem Crushing")
                 || title.equals("Emilia Shop")
                 || title.equals("Edit Emilia Shop")
                 || title.equals("Emilia - Shop")
@@ -414,6 +431,14 @@ public class MenuListener implements Listener {
                         JewelerMainMenu.openEditor(player);
                     } else {
                         JewelerMainMenu.open(player);
+                    }
+                }
+                // Jeżeli to kategoria Gemologa
+                else if (category.equalsIgnoreCase("gems_crafting")) {
+                    if (isEditMode) {
+                        GemologistMainMenu.openEditor(player);
+                    } else {
+                        GemologistMainMenu.open(player);
                     }
                 }
                 // Inne kategorie (keys, lootboxes, itd.)
@@ -1185,6 +1210,48 @@ public class MenuListener implements Listener {
         }
     }
 
+    private void handleGemologistMenuClick(Player player, String itemName) {
+        if (itemName == null) return;
+
+        switch (itemName) {
+            case "Gem Crafting":
+                CategoryMenu.open(player, "gems_crafting", 0);
+                break;
+            case "Gem Actions":
+                Bukkit.dispatchCommand(Bukkit.getConsoleSender(), "gem_actions " + player.getName());
+                break;
+            case "Gem Crushing":
+                GemCrushingCommand.openMenuWithoutPermissionCheck(player);
+                break;
+            case "Back":
+                MainMenu.open(player);
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void handleEditGemologistMenuClick(Player player, String itemName) {
+        if (itemName == null) return;
+
+        switch (itemName) {
+            case "Gem Crafting":
+                CategoryMenu.openEditor(player, "gems_crafting", 0);
+                break;
+            case "Gem Actions":
+                Bukkit.dispatchCommand(Bukkit.getConsoleSender(), "gem_actions " + player.getName());
+                break;
+            case "Gem Crushing":
+                GemCrushingCommand.openMenuWithoutPermissionCheck(player);
+                break;
+            case "Back":
+                MainMenu.openEditor(player);
+                break;
+            default:
+                break;
+        }
+    }
+
     private void handleJewelsCrushingMenuClick(InventoryClickEvent event, Player player, ItemStack clickedItem, String itemName) {
         int slot = event.getRawSlot();
         Inventory inv = event.getInventory();
@@ -1303,6 +1370,72 @@ public class MenuListener implements Listener {
         if (debuggingFlag == 1) {
             Bukkit.getLogger().info("[MenuListener] Cancelling click on UI element, slot: " + slot);
         }
+        event.setCancelled(true);
+    }
+
+    private void handleGemCrushingMenuClick(InventoryClickEvent event, Player player, ItemStack clickedItem, String itemName) {
+        int slot = event.getRawSlot();
+        Inventory inv = event.getInventory();
+
+        if (event.getClickedInventory() == null) {
+            return;
+        }
+
+        if (slot < 18 && event.getClickedInventory().equals(event.getView().getTopInventory())) {
+            if (event.getAction().name().contains("PLACE")) {
+                ItemStack cursor = event.getCursor();
+                if (cursor != null && cursor.getType() != Material.AIR) {
+                    if (!GemCrushingMenu.isGem(cursor)) {
+                        player.sendMessage(ChatColor.RED + "You can only place gems here!");
+                        event.setCancelled(true);
+                        return;
+                    }
+                }
+            } else if (event.getAction().name().contains("SHIFT") &&
+                    event.getClickedInventory().equals(event.getView().getBottomInventory())) {
+                ItemStack currentItem = event.getCurrentItem();
+                if (currentItem != null && currentItem.getType() != Material.AIR) {
+                    if (!GemCrushingMenu.isGem(currentItem)) {
+                        player.sendMessage(ChatColor.RED + "You can only place gems in the crushing menu!");
+                        event.setCancelled(true);
+                        return;
+                    }
+
+                    boolean placed = false;
+                    for (int i = 0; i < 18; i++) {
+                        if (inv.getItem(i) == null || inv.getItem(i).getType() == Material.AIR) {
+                            ItemStack toPlace = currentItem.clone();
+                            inv.setItem(i, toPlace);
+                            currentItem.setAmount(0);
+                            placed = true;
+                            break;
+                        }
+                    }
+
+                    if (!placed) {
+                        player.sendMessage(ChatColor.RED + "No space available in the crushing area!");
+                    }
+
+                    event.setCancelled(true);
+                    return;
+                }
+            }
+
+            event.setCancelled(false);
+            return;
+        }
+
+        if (event.getClickedInventory().equals(event.getView().getBottomInventory())) {
+            event.setCancelled(false);
+            return;
+        }
+
+        if (slot == 22 && itemName != null && itemName.equals("Confirm Crushing")) {
+            GemCrushingMenu.processGems(player, inv);
+            event.setCancelled(true);
+            return;
+        }
+
         event.setCancelled(true);
     }
 

--- a/src/main/java/com/maks/mycraftingplugin2/MineShopCommand.java
+++ b/src/main/java/com/maks/mycraftingplugin2/MineShopCommand.java
@@ -1,0 +1,25 @@
+package com.maks.mycraftingplugin2;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+/**
+ * /mine_shop - Opens the mine shop crafting menu.
+ */
+public class MineShopCommand implements CommandExecutor {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command.");
+            return true;
+        }
+
+        Player player = (Player) sender;
+        MainMenu.open(player);
+        return true;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -14,6 +14,14 @@ commands:
     usage: /editcrafting
     permission: mycraftingplugin.editlayout
     permission-message: You don't have permission to use this command.
+  mine_shop:
+    description: "Opens the mine shop crafting menu"
+    usage: /mine_shop
+    permission: mycraftingplugin.use
+  edit_mine_shop:
+    description: "Opens the mine shop crafting menu in edit mode"
+    usage: /edit_mine_shop
+    permission: mycraftingplugin.editlayout
   alchemy:
     description: "Open Alchemy menu"
     permission: mycraftingplugin.use
@@ -34,6 +42,18 @@ commands:
     usage: /jewels_crushing
     permission: mycraftingplugin.use
     aliases: [crushingj, jcrushing]
+  gemologist:
+    description: "Opens the gemologist menu"
+    usage: /gemologist
+    permission: mycraftingplugin.use
+  edit_gemologist:
+    description: "Opens the gemologist menu in edit mode"
+    usage: /edit_gemologist
+    permission: mycraftingplugin.editlayout
+  gem_crushing:
+    description: "Opens the gem crushing menu"
+    usage: /gem_crushing
+    permission: mycraftingplugin.use
   emilia:
     description: "Opens Emilia's shop menu"
     usage: /emilia


### PR DESCRIPTION
## Summary
- add `/gemologist` and `/edit_gemologist` commands with a gem-focused menu
- integrate new `/gem_crushing` menu that turns defined gems into Shiny Dust
- allow menu access to `/gem_actions` through Gemologist GUI
- add `/mine_shop` and `/edit_mine_shop` commands as additional crafting menu entry

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68972ebf1810832a9d0c2d7300ffda4b