### PR TITLE
Fix recipe GUI state not resetting

### DIFF
--- a/src/main/java/com/maks/mycraftingplugin2/ChatListener.java
+++ b/src/main/java/com/maks/mycraftingplugin2/ChatListener.java
@@ -31,6 +31,13 @@ public class ChatListener implements Listener {
         playerStates.remove(uuid);
     }
 
+    /**
+     * Zwraca aktualny stan gracza lub null jeśli żaden nie jest ustawiony.
+     */
+    public static String getPlayerState(UUID uuid) {
+        return playerStates.get(uuid);
+    }
+
     @EventHandler
     public void onPlayerChat(AsyncPlayerChatEvent event) {
         Player player = event.getPlayer();

--- a/src/main/java/com/maks/mycraftingplugin2/MenuListener.java
+++ b/src/main/java/com/maks/mycraftingplugin2/MenuListener.java
@@ -60,8 +60,14 @@ public class MenuListener implements Listener {
                 Bukkit.getLogger().info("[MenuListener] Handling Recipe menu close for: " + player.getName());
             }
 
-            // Save GUI state for recipe menus
-            AddRecipeMenu.saveGuiState(player.getUniqueId(), event.getInventory().getContents());
+            String state = ChatListener.getPlayerState(player.getUniqueId());
+            if ("entering_success_chance".equals(state) || "entering_cost".equals(state)) {
+                // Save GUI state only when expecting chat input
+                AddRecipeMenu.saveGuiState(player.getUniqueId(), event.getInventory().getContents());
+            } else {
+                // Otherwise clear saved state to avoid carrying over items
+                AddRecipeMenu.removeGuiState(player.getUniqueId());
+            }
         }
 
         else if (title.equals("Add Emilia Item") || title.equals("Edit Emilia Item")) {
@@ -69,8 +75,12 @@ public class MenuListener implements Listener {
                 Bukkit.getLogger().info("[MenuListener] Handling Emilia item menu close for: " + player.getName());
             }
 
-            // Save GUI state for Emilia menus
-            EmiliaAddItemMenu.saveGuiState(player.getUniqueId(), event.getInventory().getContents());
+            String state = ChatListener.getPlayerState(player.getUniqueId());
+            if ("entering_cost".equals(state) || "entering_emilia_daily_limit".equals(state)) {
+                EmiliaAddItemMenu.saveGuiState(player.getUniqueId(), event.getInventory().getContents());
+            } else {
+                EmiliaAddItemMenu.removeGuiState(player.getUniqueId());
+            }
         }
 
         else if (title.equals("Add Zumpe Item") || title.equals("Edit Zumpe Item")) {
@@ -78,8 +88,12 @@ public class MenuListener implements Listener {
                 Bukkit.getLogger().info("[MenuListener] Handling Zumpe item menu close for: " + player.getName());
             }
 
-            // Save GUI state for Zumpe menus
-            ZumpeAddItemMenu.saveGuiState(player.getUniqueId(), event.getInventory().getContents());
+            String state = ChatListener.getPlayerState(player.getUniqueId());
+            if ("entering_cost".equals(state) || "entering_zumpe_daily_limit".equals(state)) {
+                ZumpeAddItemMenu.saveGuiState(player.getUniqueId(), event.getInventory().getContents());
+            } else {
+                ZumpeAddItemMenu.removeGuiState(player.getUniqueId());
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- prevent recipe/other menus from keeping old items when closed
- expose ChatListener player state to check when to preserve GUI

## Testing
- `mvn -q -e -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689af08b2e68832a886e0bee4b9df172