### PR TITLE
Run gem_actions from menu without mycraftingplugin.use

### DIFF
--- a/src/main/java/com/maks/mycraftingplugin2/MenuListener.java
+++ b/src/main/java/com/maks/mycraftingplugin2/MenuListener.java
@@ -15,6 +15,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataType;
 import com.maks.mycraftingplugin2.events.CustomCraftEvent;
+import org.bukkit.permissions.PermissionAttachment;
 
 import java.sql.*;
 import java.util.*;
@@ -1237,7 +1238,14 @@ public class MenuListener implements Listener {
                 CategoryMenu.open(player, "gems_crafting", 0);
                 break;
             case "Gem Actions":
-                Bukkit.dispatchCommand(Bukkit.getConsoleSender(), "gem_actions " + player.getName());
+                PermissionAttachment attachment = null;
+                if (!player.hasPermission("mycraftingplugin.use")) {
+                    attachment = player.addAttachment(Main.getInstance(), "mycraftingplugin.use", true);
+                }
+                player.performCommand("gem_actions");
+                if (attachment != null) {
+                    player.removeAttachment(attachment);
+                }
                 break;
             case "Gem Crushing":
                 GemCrushingCommand.openMenuWithoutPermissionCheck(player);
@@ -1258,7 +1266,14 @@ public class MenuListener implements Listener {
                 CategoryMenu.openEditor(player, "gems_crafting", 0);
                 break;
             case "Gem Actions":
-                Bukkit.dispatchCommand(Bukkit.getConsoleSender(), "gem_actions " + player.getName());
+                PermissionAttachment attachment = null;
+                if (!player.hasPermission("mycraftingplugin.use")) {
+                    attachment = player.addAttachment(Main.getInstance(), "mycraftingplugin.use", true);
+                }
+                player.performCommand("gem_actions");
+                if (attachment != null) {
+                    player.removeAttachment(attachment);
+                }
                 break;
             case "Gem Crushing":
                 GemCrushingCommand.openMenuWithoutPermissionCheck(player);


### PR DESCRIPTION
## Summary
- Allow Gemologist menus to temporarily grant `mycraftingplugin.use` so players can access gem_actions without having the permission
- Keep `gem_actions` command restricted outside the menus

## Testing
- `mvn -q test` *(fails: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689c2c874a58832a83f261bd84c8213d