### PR TITLE
Add fisherman shop category

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ database:
 | `/editcrafting` | mycraftingplugin.editlayout | Opens the crafting menu in edit mode |
 | `/mine_shop` | mycraftingplugin.use | Opens the mine shop menu |
 | `/edit_mine_shop` | mycraftingplugin.editlayout | Opens the mine shop menu in edit mode |
+| `/fisherman_shop` | mycraftingplugin.use | Opens the fisherman shop menu |
+| `/edit_fisherman_shop` | mycraftingplugin.editlayout | Opens the fisherman shop menu in edit mode |
 | `/alchemy` | mycraftingplugin.use | Opens the alchemy menu |
 | `/edit_alchemy` | mycraftingplugin.editlayout | Opens the alchemy menu in edit mode |
 | `/jeweler` or `/jew` | mycraftingplugin.use | Opens the jeweler menu |

--- a/src/main/java/com/maks/mycraftingplugin2/EditFishermanShopCommand.java
+++ b/src/main/java/com/maks/mycraftingplugin2/EditFishermanShopCommand.java
@@ -1,0 +1,32 @@
+package com.maks.mycraftingplugin2;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+/**
+ * /edit_fisherman_shop - Opens the fisherman shop crafting menu in edit mode.
+ */
+public class EditFishermanShopCommand implements CommandExecutor {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command.");
+            return true;
+        }
+
+        Player player = (Player) sender;
+
+        if (!player.hasPermission("mycraftingplugin.editlayout")) {
+            player.sendMessage(ChatColor.RED + "You don't have permission to edit the fisherman shop layout.");
+            return true;
+        }
+
+        CategoryMenu.openEditor(player, "fisherman_shop", 0);
+
+        return true;
+    }
+}

--- a/src/main/java/com/maks/mycraftingplugin2/FishermanShopCommand.java
+++ b/src/main/java/com/maks/mycraftingplugin2/FishermanShopCommand.java
@@ -1,0 +1,26 @@
+package com.maks.mycraftingplugin2;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+/**
+ * /fisherman_shop - Opens the fisherman shop crafting menu.
+ */
+public class FishermanShopCommand implements CommandExecutor {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command.");
+            return true;
+        }
+
+        Player player = (Player) sender;
+        CategoryMenu.open(player, "fisherman_shop", 0);
+
+        return true;
+    }
+}

--- a/src/main/java/com/maks/mycraftingplugin2/Main.java
+++ b/src/main/java/com/maks/mycraftingplugin2/Main.java
@@ -39,6 +39,8 @@ public class Main extends JavaPlugin {
         getCommand("editcrafting").setExecutor(new EditCraftingCommand());
         getCommand("mine_shop").setExecutor(new MineShopCommand());
         getCommand("edit_mine_shop").setExecutor(new EditMineShopCommand());
+        getCommand("fisherman_shop").setExecutor(new FishermanShopCommand());
+        getCommand("edit_fisherman_shop").setExecutor(new EditFishermanShopCommand());
         getCommand("alchemy").setExecutor(new AlchemyCommand());
         getCommand("edit_alchemy").setExecutor(new EditAlchemyCommand());
         getCommand("jeweler").setExecutor(new JewelerCommand());

--- a/src/main/java/com/maks/mycraftingplugin2/MenuListener.java
+++ b/src/main/java/com/maks/mycraftingplugin2/MenuListener.java
@@ -457,7 +457,7 @@ public class MenuListener implements Listener {
                     }
                 }
                 // Jeżeli to kategoria Mine Shop
-                else if (category.equalsIgnoreCase("mine_shop")) {
+                else if (category.equalsIgnoreCase("mine_shop") || category.equalsIgnoreCase("fisherman_shop")) {
                     player.closeInventory();
                 }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -22,6 +22,14 @@ commands:
     description: "Opens the mine shop crafting menu in edit mode"
     usage: /edit_mine_shop
     permission: mycraftingplugin.editlayout
+  fisherman_shop:
+    description: "Opens the fisherman shop crafting menu"
+    usage: /fisherman_shop
+    permission: mycraftingplugin.use
+  edit_fisherman_shop:
+    description: "Opens the fisherman shop crafting menu in edit mode"
+    usage: /edit_fisherman_shop
+    permission: mycraftingplugin.editlayout
   alchemy:
     description: "Open Alchemy menu"
     permission: mycraftingplugin.use


### PR DESCRIPTION
## Summary
- add fisherman shop commands for normal and edit modes
- register fisherman shop commands and menu handling
- document fisherman shop in README and plugin.yml

## Testing
- `mvn -q test` *(fails: PluginResolutionException: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:3.3.1)*

------
https://chatgpt.com/codex/tasks/task_e_689ed2be253c832ab31b8d8e112a5e65