### PR TITLE
Add runemaster category with rune crushing

### DIFF
--- a/src/main/java/com/maks/mycraftingplugin2/EditRunemasterCommand.java
+++ b/src/main/java/com/maks/mycraftingplugin2/EditRunemasterCommand.java
@@ -1,0 +1,31 @@
+package com.maks.mycraftingplugin2;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+/**
+ * /edit_runemaster - Opens the runemaster menu in edit mode.
+ */
+public class EditRunemasterCommand implements CommandExecutor {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command.");
+            return true;
+        }
+
+        Player player = (Player) sender;
+
+        if (!player.hasPermission("mycraftingplugin.editlayout")) {
+            player.sendMessage(ChatColor.RED + "You don't have permission to edit the runemaster layout.");
+            return true;
+        }
+
+        RunemasterMainMenu.openEditor(player);
+        return true;
+    }
+}

--- a/src/main/java/com/maks/mycraftingplugin2/Main.java
+++ b/src/main/java/com/maks/mycraftingplugin2/Main.java
@@ -49,6 +49,9 @@ public class Main extends JavaPlugin {
         getCommand("gemologist").setExecutor(new GemologistCommand());
         getCommand("edit_gemologist").setExecutor(new EditGemologistCommand());
         getCommand("gem_crushing").setExecutor(new GemCrushingCommand());
+        getCommand("runemaster").setExecutor(new RunemasterCommand());
+        getCommand("edit_runemaster").setExecutor(new EditRunemasterCommand());
+        getCommand("runes_crushing").setExecutor(new RunesCrushingCommand());
         getCommand("emilia").setExecutor(new EmiliaCommand());
         getCommand("edit_emilia").setExecutor(new EditEmiliaCommand());
         getCommand("zumpe").setExecutor(new ZumpeCommand());

--- a/src/main/java/com/maks/mycraftingplugin2/RunemasterCommand.java
+++ b/src/main/java/com/maks/mycraftingplugin2/RunemasterCommand.java
@@ -1,0 +1,25 @@
+package com.maks.mycraftingplugin2;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+/**
+ * /runemaster - Opens the runemaster menu (normal GUI for browsing).
+ */
+public class RunemasterCommand implements CommandExecutor {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command.");
+            return true;
+        }
+
+        Player player = (Player) sender;
+        RunemasterMainMenu.open(player);
+        return true;
+    }
+}

--- a/src/main/java/com/maks/mycraftingplugin2/RunemasterMainMenu.java
+++ b/src/main/java/com/maks/mycraftingplugin2/RunemasterMainMenu.java
@@ -1,0 +1,59 @@
+package com.maks.mycraftingplugin2;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+/**
+ * Main menu for the Runemaster (normal and edit mode).
+ */
+public class RunemasterMainMenu {
+
+    public static void open(Player player) {
+        Inventory inv = Bukkit.createInventory(null, 27, "Runemaster Menu");
+
+        inv.setItem(11, createMenuItem(Material.EMERALD, ChatColor.GREEN + "Runes Upgrading"));
+        inv.setItem(15, createMenuItem(Material.GRINDSTONE, ChatColor.GREEN + "Rune Crushing"));
+
+        fillWithGlass(inv);
+        player.openInventory(inv);
+    }
+
+    public static void openEditor(Player player) {
+        Inventory inv = Bukkit.createInventory(null, 27, "Edit Runemaster Menu");
+
+        inv.setItem(11, createMenuItem(Material.EMERALD, ChatColor.GREEN + "Runes Upgrading"));
+        inv.setItem(15, createMenuItem(Material.GRINDSTONE, ChatColor.GREEN + "Rune Crushing"));
+
+        fillWithGlass(inv);
+        player.openInventory(inv);
+    }
+
+    private static ItemStack createMenuItem(Material material, String name) {
+        ItemStack item = new ItemStack(material);
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(name);
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    private static void fillWithGlass(Inventory inv) {
+        ItemStack glass = new ItemStack(Material.BLACK_STAINED_GLASS_PANE);
+        ItemMeta meta = glass.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(" ");
+            glass.setItemMeta(meta);
+        }
+        for (int i = 0; i < inv.getSize(); i++) {
+            if (inv.getItem(i) == null) {
+                inv.setItem(i, glass);
+            }
+        }
+    }
+}

--- a/src/main/java/com/maks/mycraftingplugin2/RunesCrushingCommand.java
+++ b/src/main/java/com/maks/mycraftingplugin2/RunesCrushingCommand.java
@@ -1,0 +1,33 @@
+package com.maks.mycraftingplugin2;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+/**
+ * /runes_crushing - Opens the rune crushing menu directly.
+ */
+public class RunesCrushingCommand implements CommandExecutor {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command.");
+            return true;
+        }
+
+        Player player = (Player) sender;
+        RunesCrushingMenu.open(player);
+        return true;
+    }
+
+    /**
+     * Opens the rune crushing menu directly, bypassing permission checks.
+     * Should only be used internally.
+     */
+    public static void openMenuWithoutPermissionCheck(Player player) {
+        RunesCrushingMenu.open(player);
+    }
+}

--- a/src/main/java/com/maks/mycraftingplugin2/RunesCrushingMenu.java
+++ b/src/main/java/com/maks/mycraftingplugin2/RunesCrushingMenu.java
@@ -1,0 +1,179 @@
+package com.maks.mycraftingplugin2;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Menu for crushing runes into Rune Dust.
+ */
+public class RunesCrushingMenu {
+
+    private static final List<String> RUNE_NAMES = List.of(
+            "Uruz",
+            "Algiz",
+            "Shield",
+            "Thurisaz",
+            "Wunjo",
+            "Laguz",
+            "Gebo",
+            "Ehwaz",
+            "Berkano"
+    );
+
+    public static void open(Player player) {
+        Inventory inv = Bukkit.createInventory(null, 27, "Rune Crushing");
+
+        for (int i = 0; i < inv.getSize(); i++) {
+            if (i < 18) {
+                continue;
+            } else if (i == 22) {
+                ItemStack confirmButton = new ItemStack(Material.EMERALD);
+                ItemMeta meta = confirmButton.getItemMeta();
+                if (meta != null) {
+                    meta.setDisplayName(ChatColor.GREEN + "Confirm Crushing");
+                    List<String> lore = new ArrayList<>();
+                    lore.add(ChatColor.GRAY + "Click to crush all runes");
+                    lore.add(ChatColor.GRAY + "and receive Rune Dust");
+                    meta.setLore(lore);
+                    confirmButton.setItemMeta(meta);
+                }
+                inv.setItem(i, confirmButton);
+            } else {
+                ItemStack glass = new ItemStack(Material.BLACK_STAINED_GLASS_PANE);
+                ItemMeta meta = glass.getItemMeta();
+                if (meta != null) {
+                    meta.setDisplayName(" ");
+                    glass.setItemMeta(meta);
+                }
+                inv.setItem(i, glass);
+            }
+        }
+
+        player.openInventory(inv);
+    }
+
+    public static boolean isRune(ItemStack item) {
+        if (item == null || !item.hasItemMeta() || !item.getItemMeta().hasDisplayName()) {
+            return false;
+        }
+
+        ItemMeta meta = item.getItemMeta();
+        String displayName = ChatColor.stripColor(meta.getDisplayName());
+
+        boolean hasTier = displayName.contains("[ I ]") || displayName.contains("[ II ]") || displayName.contains("[ III ]");
+        if (!hasTier) {
+            return false;
+        }
+
+        boolean isKnownRune = false;
+        for (String name : RUNE_NAMES) {
+            if (displayName.contains(name)) {
+                isKnownRune = true;
+                break;
+            }
+        }
+        if (!isKnownRune) {
+            return false;
+        }
+
+        return meta.hasEnchant(Enchantment.DURABILITY);
+    }
+
+    public static int getRuneTier(ItemStack item) {
+        if (item == null || !item.hasItemMeta() || !item.getItemMeta().hasDisplayName()) {
+            return 0;
+        }
+        String displayName = item.getItemMeta().getDisplayName();
+        if (displayName.contains("[ I ]")) {
+            return 1;
+        } else if (displayName.contains("[ II ]")) {
+            return 2;
+        } else if (displayName.contains("[ III ]")) {
+            return 3;
+        }
+        return 0;
+    }
+
+    public static void processRunes(Player player, Inventory inv) {
+        int totalDust = 0;
+        List<Integer> slotsToEmpty = new ArrayList<>();
+
+        for (int i = 0; i < 18; i++) {
+            ItemStack item = inv.getItem(i);
+            if (item != null && isRune(item)) {
+                int tier = getRuneTier(item);
+                int amount = item.getAmount();
+                if (tier > 0) {
+                    totalDust += tier * amount;
+                    slotsToEmpty.add(i);
+                }
+            }
+        }
+
+        if (totalDust > 0) {
+            ItemStack dust = createRuneDust(totalDust);
+            if (player.getInventory().firstEmpty() != -1) {
+                player.getInventory().addItem(dust);
+                for (int slot : slotsToEmpty) {
+                    inv.setItem(slot, null);
+                }
+                player.sendMessage(ChatColor.GREEN + "You crushed runes and received " + totalDust + " Rune Dust!");
+            } else {
+                player.sendMessage(ChatColor.RED + "Your inventory is full! Make space before crushing runes.");
+            }
+        } else {
+            player.sendMessage(ChatColor.RED + "No valid runes to crush!");
+        }
+    }
+
+    public static void returnItemsToPlayer(Player player, Inventory inv) {
+        List<ItemStack> itemsToReturn = new ArrayList<>();
+        for (int i = 0; i < 18; i++) {
+            ItemStack item = inv.getItem(i);
+            if (item != null && item.getType() != Material.AIR) {
+                itemsToReturn.add(item.clone());
+                inv.setItem(i, null);
+            }
+        }
+
+        for (ItemStack item : itemsToReturn) {
+            player.getInventory().addItem(item);
+        }
+    }
+
+    private static ItemStack createRuneDust(int amount) {
+        try {
+            Class<?> itemManagerClass = Class.forName("com.maks.trinketsplugin.ItemManager");
+            java.lang.reflect.Method getItemMethod = itemManagerClass.getMethod("getItem", String.class, int.class);
+            Object result = getItemMethod.invoke(null, "rune_dust", amount);
+            if (result instanceof ItemStack) {
+                return (ItemStack) result;
+            }
+        } catch (Exception ignored) {
+        }
+
+        ItemStack dust = new ItemStack(Material.CLAY_BALL, amount);
+        ItemMeta meta = dust.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName("§cRune Dust");
+            List<String> lore = new ArrayList<>();
+            lore.add("§o§7Used to upgrade runes");
+            meta.setLore(lore);
+            meta.addEnchant(Enchantment.DURABILITY, 10, true);
+            meta.addItemFlags(ItemFlag.HIDE_ENCHANTS, ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_UNBREAKABLE);
+            meta.setUnbreakable(true);
+            dust.setItemMeta(meta);
+        }
+        return dust;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -62,6 +62,18 @@ commands:
     description: "Opens the gem crushing menu"
     usage: /gem_crushing
     permission: mycraftingplugin.use
+  runemaster:
+    description: "Opens the runemaster menu"
+    usage: /runemaster
+    permission: mycraftingplugin.use
+  edit_runemaster:
+    description: "Opens the runemaster menu in edit mode"
+    usage: /edit_runemaster
+    permission: mycraftingplugin.editlayout
+  runes_crushing:
+    description: "Opens the rune crushing menu"
+    usage: /runes_crushing
+    permission: mycraftingplugin.use
   emilia:
     description: "Opens Emilia's shop menu"
     usage: /emilia


### PR DESCRIPTION
## Summary
- add Runemaster menu with rune upgrading and rune crushing options
- implement Rune Crushing mechanics to convert runes into Rune Dust
- wire up runemaster commands and plugin configuration
- ensure rune crushing yields Rune Dust instead of Jewel Dust

## Testing
- `mvn -e -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f1c9bd4cc832a8fc8b84f5cba8219