### PR TITLE
Enable fishing command from Fisherman shop

### DIFF
--- a/src/main/java/com/maks/mycraftingplugin2/MenuListener.java
+++ b/src/main/java/com/maks/mycraftingplugin2/MenuListener.java
@@ -497,6 +497,15 @@ public class MenuListener implements Listener {
                 // Jeżeli to kategoria Fisherman Shop
                 else if (category.equalsIgnoreCase("fisherman_shop")) {
                     player.closeInventory();
+                    boolean hadPerm = player.hasPermission("fishing.use");
+                    if (hadPerm) {
+                        player.performCommand("fishing");
+                    } else {
+                        PermissionAttachment attachment = player.addAttachment(Main.getInstance());
+                        attachment.setPermission("fishing.use", true);
+                        player.performCommand("fishing");
+                        player.removeAttachment(attachment);
+                    }
                 }
 
                 // Inne kategorie (keys, lootboxes, itd.)


### PR DESCRIPTION
## Summary
- allow Fisherman Shop GUI back button to run `/fishing` with temporary `fishing.use` permission

## Testing
- `mvn -q test` *(fails: Could not resolve Maven plugin; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f496baab8832a92f4f8b4f4ba610c