### PR TITLE
Add Conjurej shop with recipe unlocking

### DIFF
--- a/src/main/java/com/maks/mycraftingplugin2/AddRecipeMenu.java
+++ b/src/main/java/com/maks/mycraftingplugin2/AddRecipeMenu.java
@@ -27,6 +27,11 @@ public class AddRecipeMenu {
         // Jeśli gracz ma zapisany stan GUI, przywróć go
         if (guiStates.containsKey(player.getUniqueId())) {
             inv.setContents(guiStates.get(player.getUniqueId()));
+            if ("conjurej_shop".equalsIgnoreCase(category)) {
+                String required = TemporaryData.getRequiredRecipe(player.getUniqueId());
+                String display = (required != null) ? required : "None";
+                inv.setItem(25, createInfoItem("Required Recipe", display));
+            }
         } else {
             // Ustaw pola na wymagane przedmioty (sloty 0-9)
             for (int i = 0; i < 10; i++) {
@@ -60,6 +65,15 @@ public class AddRecipeMenu {
             inv.setItem(22, createMenuItem(
                     Material.EMERALD, ChatColor.GREEN + "Save"
             ));
+
+            // Required recipe selector for Conjurej shop
+            if ("conjurej_shop".equalsIgnoreCase(category)) {
+                String required = TemporaryData.getRequiredRecipe(player.getUniqueId());
+                String display = (required != null) ? required : "None";
+                inv.setItem(25, createInfoItem("Required Recipe", display));
+            } else {
+                TemporaryData.removeRequiredRecipe(player.getUniqueId());
+            }
 
             // Przycisk "Back" (slot 24)
             inv.setItem(24, createMenuItem(

--- a/src/main/java/com/maks/mycraftingplugin2/ConjurejMainMenu.java
+++ b/src/main/java/com/maks/mycraftingplugin2/ConjurejMainMenu.java
@@ -1,0 +1,60 @@
+package com.maks.mycraftingplugin2;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+/**
+ * Main menu for the Conjurej system. Provides access to the
+ * conjurej crafting shop and a placeholder for future features.
+ */
+public class ConjurejMainMenu {
+
+    public static void open(Player player) {
+        Inventory inv = Bukkit.createInventory(null, 27, "Conjurej Menu");
+
+        inv.setItem(11, createMenuItem(Material.BOOK, ChatColor.GREEN + "Conjurej Shop"));
+        inv.setItem(15, createMenuItem(Material.ENCHANTED_BOOK, ChatColor.YELLOW + "Conjuration"));
+
+        fillWithGlass(inv);
+        player.openInventory(inv);
+    }
+
+    public static void openEditor(Player player) {
+        Inventory inv = Bukkit.createInventory(null, 27, "Edit Conjurej Menu");
+
+        inv.setItem(11, createMenuItem(Material.BOOK, ChatColor.GREEN + "Conjurej Shop"));
+        inv.setItem(15, createMenuItem(Material.ENCHANTED_BOOK, ChatColor.YELLOW + "Conjuration"));
+
+        fillWithGlass(inv);
+        player.openInventory(inv);
+    }
+
+    private static ItemStack createMenuItem(Material material, String name) {
+        ItemStack item = new ItemStack(material);
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(name);
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    private static void fillWithGlass(Inventory inv) {
+        ItemStack glass = new ItemStack(Material.BLACK_STAINED_GLASS_PANE);
+        ItemMeta meta = glass.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(" ");
+            glass.setItemMeta(meta);
+        }
+        for (int i = 0; i < inv.getSize(); i++) {
+            if (inv.getItem(i) == null) {
+                inv.setItem(i, glass);
+            }
+        }
+    }
+}

--- a/src/main/java/com/maks/mycraftingplugin2/ConjurejRecipeDropListener.java
+++ b/src/main/java/com/maks/mycraftingplugin2/ConjurejRecipeDropListener.java
@@ -1,0 +1,46 @@
+package com.maks.mycraftingplugin2;
+
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDeathEvent;
+
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+
+/**
+ * Handles dropping of Conjurej recipes from MythicMobs.
+ * Uses metadata "MythicType" to identify MythicMobs without
+ * requiring a direct dependency on the MythicMobs API.
+ */
+public class ConjurejRecipeDropListener implements Listener {
+
+    private static final double DROP_CHANCE = 0.001; // 0.1%
+    private final Random random = new Random();
+
+    @EventHandler
+    public void onEntityDeath(EntityDeathEvent event) {
+        Player killer = event.getEntity().getKiller();
+        if (killer == null) return;
+
+        Entity entity = event.getEntity();
+        if (!entity.hasMetadata("MythicType")) return;
+        String mobId = entity.getMetadata("MythicType").get(0).asString();
+
+        List<String> allowed = Main.getInstance().getConfig().getStringList("conjurej.mob_ids");
+        if (!allowed.contains(mobId)) return;
+
+        if (random.nextDouble() >= DROP_CHANCE) return;
+
+        UUID uuid = killer.getUniqueId();
+        List<String> locked = ConjurejRecipeUnlockManager.getLockedRecipes(uuid);
+        if (locked.isEmpty()) return;
+
+        String recipe = locked.get(random.nextInt(locked.size()));
+        ConjurejRecipeUnlockManager.unlockRecipe(killer, recipe);
+        killer.sendMessage(ChatColor.AQUA + "You feel knowledge flow through you...");
+    }
+}

--- a/src/main/java/com/maks/mycraftingplugin2/ConjurejRecipeSelectMenu.java
+++ b/src/main/java/com/maks/mycraftingplugin2/ConjurejRecipeSelectMenu.java
@@ -1,0 +1,62 @@
+package com.maks.mycraftingplugin2;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.List;
+
+/**
+ * Menu for selecting which Conjurej recipe is required for a crafting recipe.
+ */
+public class ConjurejRecipeSelectMenu {
+
+    public static void open(Player player) {
+        Inventory inv = Bukkit.createInventory(null, 27, "Select Required Recipe");
+
+        List<String> recipes = ConjurejRecipeUnlockManager.getAllRecipes();
+        int index = 0;
+        for (String recipe : recipes) {
+            ItemStack item = new ItemStack(Material.PAPER);
+            ItemMeta meta = item.getItemMeta();
+            if (meta != null) {
+                meta.setDisplayName(ChatColor.YELLOW + recipe);
+                item.setItemMeta(meta);
+            }
+            inv.setItem(index++, item);
+        }
+
+        inv.setItem(26, createMenuItem(Material.ARROW, ChatColor.YELLOW + "Back"));
+
+        fillWithGlass(inv);
+        player.openInventory(inv);
+    }
+
+    private static ItemStack createMenuItem(Material material, String name) {
+        ItemStack item = new ItemStack(material);
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(name);
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    private static void fillWithGlass(Inventory inv) {
+        ItemStack glass = new ItemStack(Material.BLACK_STAINED_GLASS_PANE);
+        ItemMeta meta = glass.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(" ");
+            glass.setItemMeta(meta);
+        }
+        for (int i = 0; i < inv.getSize(); i++) {
+            if (inv.getItem(i) == null) {
+                inv.setItem(i, glass);
+            }
+        }
+    }
+}

--- a/src/main/java/com/maks/mycraftingplugin2/ConjurejRecipeUnlockManager.java
+++ b/src/main/java/com/maks/mycraftingplugin2/ConjurejRecipeUnlockManager.java
@@ -1,0 +1,75 @@
+package com.maks.mycraftingplugin2;
+
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+
+import java.sql.*;
+import java.util.*;
+
+/**
+ * Manages unlocking and tracking of Conjurej recipes for players.
+ */
+public class ConjurejRecipeUnlockManager {
+
+    private static final List<String> ALL_RECIPES = Arrays.asList(
+            "Runic Tether",
+            "Surgical Sever",
+            "Blessing Theft",
+            "Hunter's Mark",
+            "Rhythmic Displacement",
+            "Crosshair Rattle",
+            "Whiplash Sprint",
+            "Mischief",
+            "Overextension"
+    );
+
+    public static List<String> getAllRecipes() {
+        return ALL_RECIPES;
+    }
+
+    public static boolean hasRecipe(UUID uuid, String recipe) {
+        if (recipe == null || recipe.isEmpty()) return true;
+        try (Connection conn = Main.getConnection();
+             PreparedStatement ps = conn.prepareStatement(
+                     "SELECT 1 FROM conjurej_recipes WHERE player_uuid=? AND recipe=?")) {
+            ps.setString(1, uuid.toString());
+            ps.setString(2, recipe);
+            try (ResultSet rs = ps.executeQuery()) {
+                return rs.next();
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    public static void unlockRecipe(Player player, String recipe) {
+        try (Connection conn = Main.getConnection();
+             PreparedStatement ps = conn.prepareStatement(
+                     "INSERT IGNORE INTO conjurej_recipes (player_uuid, recipe) VALUES (?, ?)")) {
+            ps.setString(1, player.getUniqueId().toString());
+            ps.setString(2, recipe);
+            ps.executeUpdate();
+            player.sendMessage(ChatColor.GOLD + "You have unlocked the " + recipe + " recipe!");
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static List<String> getLockedRecipes(UUID uuid) {
+        List<String> locked = new ArrayList<>(ALL_RECIPES);
+        try (Connection conn = Main.getConnection();
+             PreparedStatement ps = conn.prepareStatement(
+                     "SELECT recipe FROM conjurej_recipes WHERE player_uuid=?")) {
+            ps.setString(1, uuid.toString());
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    locked.remove(rs.getString("recipe"));
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return locked;
+    }
+}

--- a/src/main/java/com/maks/mycraftingplugin2/ConjurejShopCommand.java
+++ b/src/main/java/com/maks/mycraftingplugin2/ConjurejShopCommand.java
@@ -1,0 +1,25 @@
+package com.maks.mycraftingplugin2;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+/**
+ * /conjurej_shop - Opens the Conjurej main menu.
+ */
+public class ConjurejShopCommand implements CommandExecutor {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command.");
+            return true;
+        }
+
+        Player player = (Player) sender;
+        ConjurejMainMenu.open(player);
+        return true;
+    }
+}

--- a/src/main/java/com/maks/mycraftingplugin2/EditConjurejShopCommand.java
+++ b/src/main/java/com/maks/mycraftingplugin2/EditConjurejShopCommand.java
@@ -1,0 +1,31 @@
+package com.maks.mycraftingplugin2;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+/**
+ * /edit_conjurej_shop - Opens the Conjurej main menu in edit mode.
+ */
+public class EditConjurejShopCommand implements CommandExecutor {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command.");
+            return true;
+        }
+
+        Player player = (Player) sender;
+
+        if (!player.hasPermission("mycraftingplugin.editlayout")) {
+            player.sendMessage(ChatColor.RED + "You don't have permission to edit this menu.");
+            return true;
+        }
+
+        ConjurejMainMenu.openEditor(player);
+        return true;
+    }
+}

--- a/src/main/java/com/maks/mycraftingplugin2/Main.java
+++ b/src/main/java/com/maks/mycraftingplugin2/Main.java
@@ -58,10 +58,13 @@ public class Main extends JavaPlugin {
         getCommand("edit_zumpe").setExecutor(new EditZumpeCommand());
         getCommand("testjewels").setExecutor(new TestJewelsCommand());
         getCommand("testpouch").setExecutor(new TestPouchCommand());
+        getCommand("conjurej_shop").setExecutor(new ConjurejShopCommand());
+        getCommand("edit_conjurej_shop").setExecutor(new EditConjurejShopCommand());
 
         // Rejestracja listenerów
         getServer().getPluginManager().registerEvents(new MenuListener(), this);
         getServer().getPluginManager().registerEvents(new ChatListener(), this);
+        getServer().getPluginManager().registerEvents(new ConjurejRecipeDropListener(), this);
 
         // Schedule daily transaction cleanup at midnight
         setupTransactionCleanupTask();
@@ -159,6 +162,25 @@ public class Main extends JavaPlugin {
                 """;
 
                 statement.executeUpdate(createTable);
+
+                String updateRecipesTable = """
+                    ALTER TABLE recipes
+                    ADD COLUMN IF NOT EXISTS required_recipe VARCHAR(255)
+                """;
+                try {
+                    statement.executeUpdate(updateRecipesTable);
+                } catch (SQLException e) {
+                    getLogger().info("Recipes table update skipped: " + e.getMessage());
+                }
+
+                String createConjurejTable = """
+                    CREATE TABLE IF NOT EXISTS conjurej_recipes (
+                        player_uuid VARCHAR(36),
+                        recipe VARCHAR(255),
+                        PRIMARY KEY (player_uuid, recipe)
+                    )
+                """;
+                statement.executeUpdate(createConjurejTable);
 
                 // Create Emilia shop tables if they don't exist
                 String createEmiliaItemsTable = """

--- a/src/main/java/com/maks/mycraftingplugin2/MenuListener.java
+++ b/src/main/java/com/maks/mycraftingplugin2/MenuListener.java
@@ -177,6 +177,12 @@ public class MenuListener implements Listener {
             handleRunemasterMenuClick(player, itemName);
         } else if (title.equals("Edit Runemaster Menu")) {
             handleEditRunemasterMenuClick(player, itemName);
+        } else if (title.equals("Conjurej Menu")) {
+            handleConjurejMenuClick(player, itemName);
+        } else if (title.equals("Edit Conjurej Menu")) {
+            handleEditConjurejMenuClick(player, itemName);
+        } else if (title.equals("Select Required Recipe")) {
+            handleConjurejRecipeSelectMenu(player, itemName);
         } else if (title.equals("Rune Crushing")) {
             handleRuneCrushingMenuClick(event, player, clickedItem, itemName);
         } else if (title.equals("Emilia Shop")) {
@@ -235,6 +241,9 @@ public class MenuListener implements Listener {
                 || title.equals("Runemaster Menu")
                 || title.equals("Edit Runemaster Menu")
                 || title.equals("Rune Crushing")
+                || title.equals("Conjurej Menu")
+                || title.equals("Edit Conjurej Menu")
+                || title.equals("Select Required Recipe")
                 || title.equals("Emilia Shop")
                 || title.equals("Edit Emilia Shop")
                 || title.equals("Emilia - Shop")
@@ -341,6 +350,13 @@ public class MenuListener implements Listener {
                         } else {
                             player.closeInventory();
                         }
+                        break;
+
+                    case 25:
+                        // Required recipe selector (Conjurej shop)
+                        AddRecipeMenu.saveGuiState(player.getUniqueId(), inv.getContents());
+                        TemporaryData.setPlayerData(player.getUniqueId(), "edit_menu_title", title);
+                        ConjurejRecipeSelectMenu.open(player);
                         break;
 
                     default:
@@ -666,6 +682,14 @@ public class MenuListener implements Listener {
                 ResultSet rs = ps.executeQuery();
 
                 if (rs.next()) {
+                    String category = rs.getString("category");
+                    String required = rs.getString("required_recipe");
+                    if ("conjurej_shop".equalsIgnoreCase(category) &&
+                            !ConjurejRecipeUnlockManager.hasRecipe(player.getUniqueId(), required)) {
+                        player.sendMessage(ChatColor.RED + "You have not unlocked the " + required + " recipe.");
+                        return;
+                    }
+
                     // Sprawdź czy gracz ma wymagane przedmioty
                     boolean hasItems = true;
                     Map<Integer, ItemStack> requiredItems = new HashMap<>();
@@ -1014,8 +1038,8 @@ public class MenuListener implements Listener {
              PreparedStatement ps = conn.prepareStatement(
                      "INSERT INTO recipes (category, slot, required_item_1, required_item_2, required_item_3, " +
                              "required_item_4, required_item_5, required_item_6, required_item_7, required_item_8, " +
-                             "required_item_9, required_item_10, result_item, success_chance, cost) " +
-                             "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+                             "required_item_9, required_item_10, result_item, success_chance, cost, required_recipe) " +
+                             "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
              )) {
 
             ps.setString(1, category);
@@ -1046,12 +1070,20 @@ public class MenuListener implements Listener {
             // Koszt
             ps.setDouble(15, TemporaryData.getCost(player.getUniqueId()));
 
+            // Required recipe (only for conjurej shop)
+            String required = TemporaryData.getRequiredRecipe(player.getUniqueId());
+            if (!"conjurej_shop".equalsIgnoreCase(category)) {
+                required = null;
+            }
+            ps.setString(16, required);
+
             ps.executeUpdate();
             player.sendMessage(ChatColor.GREEN + "Recipe has been saved.");
 
             // Wyczyść dane tymczasowe
             TemporaryData.removeSuccessChance(player.getUniqueId());
             TemporaryData.removeCost(player.getUniqueId());
+            TemporaryData.removeRequiredRecipe(player.getUniqueId());
             AddRecipeMenu.removeGuiState(player.getUniqueId());
 
             // Zamiast zamykać GUI, otwórz z powrotem menu kategorii
@@ -1076,7 +1108,7 @@ public class MenuListener implements Listener {
                      "UPDATE recipes SET required_item_1=?, required_item_2=?, required_item_3=?, " +
                              "required_item_4=?, required_item_5=?, required_item_6=?, required_item_7=?, " +
                              "required_item_8=?, required_item_9=?, required_item_10=?, result_item=?, " +
-                             "success_chance=?, cost=? WHERE id=?"
+                             "success_chance=?, cost=?, required_recipe=? WHERE id=?"
              )) {
 
             // Wymagane przedmioty (sloty 0-9)
@@ -1101,7 +1133,14 @@ public class MenuListener implements Listener {
             // Szansa na sukces i koszt
             ps.setDouble(12, TemporaryData.getSuccessChance(player.getUniqueId()));
             ps.setDouble(13, TemporaryData.getCost(player.getUniqueId()));
-            ps.setInt(14, recipeId);
+
+            String required = TemporaryData.getRequiredRecipe(player.getUniqueId());
+            String category = TemporaryData.getLastCategory(player.getUniqueId());
+            if (!"conjurej_shop".equalsIgnoreCase(category)) {
+                required = null;
+            }
+            ps.setString(14, required);
+            ps.setInt(15, recipeId);
 
             int updatedRows = ps.executeUpdate();
             if (updatedRows > 0) {
@@ -1113,6 +1152,7 @@ public class MenuListener implements Listener {
             // Wyczyść dane tymczasowe
             TemporaryData.removeSuccessChance(player.getUniqueId());
             TemporaryData.removeCost(player.getUniqueId());
+            TemporaryData.removeRequiredRecipe(player.getUniqueId());
             AddRecipeMenu.removeGuiState(player.getUniqueId());
 
             // Instead of player.closeInventory();
@@ -1367,6 +1407,67 @@ public class MenuListener implements Listener {
             default:
                 break;
         }
+    }
+
+    private void handleConjurejMenuClick(Player player, String itemName) {
+        if (itemName == null) return;
+
+        switch (itemName) {
+            case "Conjurej Shop":
+                CategoryMenu.open(player, "conjurej_shop", 0);
+                break;
+            case "Conjuration":
+                player.sendMessage(ChatColor.YELLOW + "Conjuration coming soon!");
+                break;
+            case "Back":
+                MainMenu.open(player);
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void handleEditConjurejMenuClick(Player player, String itemName) {
+        if (itemName == null) return;
+
+        switch (itemName) {
+            case "Conjurej Shop":
+                CategoryMenu.openEditor(player, "conjurej_shop", 0);
+                break;
+            case "Conjuration":
+                player.sendMessage(ChatColor.YELLOW + "Conjuration coming soon!");
+                break;
+            case "Back":
+                MainMenu.openEditor(player);
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void handleConjurejRecipeSelectMenu(Player player, String itemName) {
+        if (itemName == null) return;
+
+        String title = (String) TemporaryData.getPlayerData(player.getUniqueId(), "edit_menu_title");
+        if (itemName.equals("Back")) {
+            if ("Add New Recipe".equals(title)) {
+                AddRecipeMenu.open(player, AddRecipeMenu.getCategory(player.getUniqueId()));
+            } else if ("Edit Recipe".equals(title)) {
+                EditRecipeMenu.open(player, EditRecipeMenu.getRecipeId(player.getUniqueId()));
+            } else {
+                player.closeInventory();
+            }
+        } else {
+            TemporaryData.setRequiredRecipe(player.getUniqueId(), itemName);
+            if ("Add New Recipe".equals(title)) {
+                AddRecipeMenu.open(player, AddRecipeMenu.getCategory(player.getUniqueId()));
+            } else if ("Edit Recipe".equals(title)) {
+                EditRecipeMenu.open(player, EditRecipeMenu.getRecipeId(player.getUniqueId()));
+            } else {
+                player.closeInventory();
+            }
+        }
+        TemporaryData.removePlayerData(player.getUniqueId(), "edit_menu_title");
     }
 
     private void handleJewelsCrushingMenuClick(InventoryClickEvent event, Player player, ItemStack clickedItem, String itemName) {

--- a/src/main/java/com/maks/mycraftingplugin2/TemporaryData.java
+++ b/src/main/java/com/maks/mycraftingplugin2/TemporaryData.java
@@ -68,6 +68,25 @@ public class TemporaryData {
         costs.remove(playerUUID);
     }
 
+    // Required recipe for Conjurej shop crafting
+    private static Map<UUID, String> requiredRecipes = new HashMap<>();
+
+    public static void setRequiredRecipe(UUID playerUUID, String recipe) {
+        if (recipe == null) {
+            requiredRecipes.remove(playerUUID);
+        } else {
+            requiredRecipes.put(playerUUID, recipe);
+        }
+    }
+
+    public static String getRequiredRecipe(UUID playerUUID) {
+        return requiredRecipes.get(playerUUID);
+    }
+
+    public static void removeRequiredRecipe(UUID playerUUID) {
+        requiredRecipes.remove(playerUUID);
+    }
+
     // Przechowywanie ostatnio odwiedzonej kategorii przez gracza
     private static Map<UUID, String> lastCategory = new HashMap<>();
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -7,3 +7,6 @@ database:
 
 # Enable debug mode (1 = enabled, 0 = disabled)
 debug: 1
+
+conjurej:
+  mob_ids: []

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ name: MyCraftingPlugin2
 version: '${project.version}'
 main: com.maks.mycraftingplugin2.Main
 api-version: '1.20'
-softdepend: [Vault, IngredientPouchPlugin]
+softdepend: [Vault, IngredientPouchPlugin, MythicMobs]
 commands:
   crafting:
     description: Opens the crafting menu.
@@ -89,6 +89,14 @@ commands:
   edit_zumpe:
     description: "Opens Zumpe shop menu in edit mode"
     usage: /edit_zumpe
+    permission: mycraftingplugin.editlayout
+  conjurej_shop:
+    description: "Opens the Conjurej menu"
+    usage: /conjurej_shop
+    permission: mycraftingplugin.use
+  edit_conjurej_shop:
+    description: "Opens the Conjurej menu in edit mode"
+    usage: /edit_conjurej_shop
     permission: mycraftingplugin.editlayout
   testjewels:
     description: Test jewel detection system


### PR DESCRIPTION
## Summary
- add Conjurej shop commands and menus
- require unlocking recipes from Mythic mobs before crafting
- store unlocked Conjurej recipes in database

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e1b56bf4832ab14ba7df5d2d28dd