### PR TITLE
Rename Conjurej to Conjurer and fix back navigation

### DIFF
--- a/src/main/java/com/maks/mycraftingplugin2/AddRecipeMenu.java
+++ b/src/main/java/com/maks/mycraftingplugin2/AddRecipeMenu.java
@@ -27,7 +27,7 @@ public class AddRecipeMenu {
         // Jeśli gracz ma zapisany stan GUI, przywróć go
         if (guiStates.containsKey(player.getUniqueId())) {
             inv.setContents(guiStates.get(player.getUniqueId()));
-            if ("conjurej_shop".equalsIgnoreCase(category)) {
+            if ("conjurer_shop".equalsIgnoreCase(category)) {
                 String required = TemporaryData.getRequiredRecipe(player.getUniqueId());
                 String display = (required != null) ? required : "None";
                 inv.setItem(25, createInfoItem("Required Recipe", display));
@@ -66,8 +66,8 @@ public class AddRecipeMenu {
                     Material.EMERALD, ChatColor.GREEN + "Save"
             ));
 
-            // Required recipe selector for Conjurej shop
-            if ("conjurej_shop".equalsIgnoreCase(category)) {
+            // Required recipe selector for Conjurer shop
+            if ("conjurer_shop".equalsIgnoreCase(category)) {
                 String required = TemporaryData.getRequiredRecipe(player.getUniqueId());
                 String display = (required != null) ? required : "None";
                 inv.setItem(25, createInfoItem("Required Recipe", display));

--- a/src/main/java/com/maks/mycraftingplugin2/CategoryMenu.java
+++ b/src/main/java/com/maks/mycraftingplugin2/CategoryMenu.java
@@ -48,9 +48,9 @@ public class CategoryMenu {
                     List<String> lore = meta.hasLore() ? meta.getLore() : new ArrayList<>();
                     // Format as String to avoid byte conversion issues
                     lore.add(ChatColor.GRAY + "Recipe ID: " + String.valueOf(recipeId));
-                    if ("conjurej_shop".equalsIgnoreCase(category) && required != null && !required.isEmpty()) {
+                    if ("conjurer_shop".equalsIgnoreCase(category) && required != null && !required.isEmpty()) {
                         lore.add(ChatColor.GOLD + "Requires: " + required);
-                        if (!ConjurejRecipeUnlockManager.hasRecipe(player.getUniqueId(), required)) {
+                        if (!ConjurerRecipeUnlockManager.hasRecipe(player.getUniqueId(), required)) {
                             lore.add(ChatColor.RED + "Locked");
                         }
 
@@ -122,7 +122,7 @@ public class CategoryMenu {
                     List<String> lore = meta.hasLore() ? meta.getLore() : new ArrayList<>();
                     // Format as String to avoid byte conversion issues
                     lore.add(ChatColor.GRAY + "Recipe ID: " + String.valueOf(recipeId));
-                    if ("conjurej_shop".equalsIgnoreCase(category) && required != null && !required.isEmpty()) {
+                    if ("conjurer_shop".equalsIgnoreCase(category) && required != null && !required.isEmpty()) {
                         lore.add(ChatColor.GOLD + "Requires: " + required);
                     }
                     meta.setLore(lore);

--- a/src/main/java/com/maks/mycraftingplugin2/ConjurerMainMenu.java
+++ b/src/main/java/com/maks/mycraftingplugin2/ConjurerMainMenu.java
@@ -9,15 +9,15 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
 /**
- * Main menu for the Conjurej system. Provides access to the
- * conjurej crafting shop and a placeholder for future features.
+ * Main menu for the Conjurer system. Provides access to the
+ * conjurer crafting shop and a placeholder for future features.
  */
-public class ConjurejMainMenu {
+public class ConjurerMainMenu {
 
     public static void open(Player player) {
-        Inventory inv = Bukkit.createInventory(null, 27, "Conjurej Menu");
+        Inventory inv = Bukkit.createInventory(null, 27, "Conjurer Menu");
 
-        inv.setItem(11, createMenuItem(Material.BOOK, ChatColor.GREEN + "Conjurej Shop"));
+        inv.setItem(11, createMenuItem(Material.BOOK, ChatColor.GREEN + "Conjurer Shop"));
         inv.setItem(15, createMenuItem(Material.ENCHANTED_BOOK, ChatColor.YELLOW + "Conjuration"));
 
         fillWithGlass(inv);
@@ -25,9 +25,9 @@ public class ConjurejMainMenu {
     }
 
     public static void openEditor(Player player) {
-        Inventory inv = Bukkit.createInventory(null, 27, "Edit Conjurej Menu");
+        Inventory inv = Bukkit.createInventory(null, 27, "Edit Conjurer Menu");
 
-        inv.setItem(11, createMenuItem(Material.BOOK, ChatColor.GREEN + "Conjurej Shop"));
+        inv.setItem(11, createMenuItem(Material.BOOK, ChatColor.GREEN + "Conjurer Shop"));
         inv.setItem(15, createMenuItem(Material.ENCHANTED_BOOK, ChatColor.YELLOW + "Conjuration"));
 
         fillWithGlass(inv);

--- a/src/main/java/com/maks/mycraftingplugin2/ConjurerRecipeDropListener.java
+++ b/src/main/java/com/maks/mycraftingplugin2/ConjurerRecipeDropListener.java
@@ -13,11 +13,11 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**
- * Handles dropping of Conjurej recipes from MythicMobs.
+ * Handles dropping of Conjurer recipes from MythicMobs.
  * Uses metadata "MythicType" to identify MythicMobs without
  * requiring a direct dependency on the MythicMobs API.
  */
-public class ConjurejRecipeDropListener implements Listener {
+public class ConjurerRecipeDropListener implements Listener {
 
     private final Random random = new Random();
 
@@ -30,22 +30,22 @@ public class ConjurejRecipeDropListener implements Listener {
         if (!entity.hasMetadata("MythicType")) return;
         String mobId = entity.getMetadata("MythicType").get(0).asString();
 
-        String mobsRaw = Main.getInstance().getConfig().getString("conjurej.mobs", "");
+        String mobsRaw = Main.getInstance().getConfig().getString("conjurer.mobs", "");
         List<String> allowed = Arrays.stream(mobsRaw.split("\\R"))
                 .map(String::trim)
                 .filter(line -> !line.isEmpty() && !line.startsWith("#"))
                 .collect(Collectors.toList());
         if (!allowed.contains(mobId)) return;
 
-        double dropChance = Main.getInstance().getConfig().getDouble("conjurej.recipe_drop_chance", 0.001);
+        double dropChance = Main.getInstance().getConfig().getDouble("conjurer.recipe_drop_chance", 0.001);
         if (random.nextDouble() >= dropChance) return;
 
         UUID uuid = killer.getUniqueId();
-        List<String> locked = ConjurejRecipeUnlockManager.getLockedRecipes(uuid);
+        List<String> locked = ConjurerRecipeUnlockManager.getLockedRecipes(uuid);
         if (locked.isEmpty()) return;
 
         String recipe = locked.get(random.nextInt(locked.size()));
-        ConjurejRecipeUnlockManager.unlockRecipe(killer, recipe);
+        ConjurerRecipeUnlockManager.unlockRecipe(killer, recipe);
         killer.sendMessage(ChatColor.AQUA + "You feel knowledge flow through you...");
     }
 }

--- a/src/main/java/com/maks/mycraftingplugin2/ConjurerRecipeSelectMenu.java
+++ b/src/main/java/com/maks/mycraftingplugin2/ConjurerRecipeSelectMenu.java
@@ -11,14 +11,14 @@ import org.bukkit.inventory.meta.ItemMeta;
 import java.util.List;
 
 /**
- * Menu for selecting which Conjurej recipe is required for a crafting recipe.
+ * Menu for selecting which Conjurer recipe is required for a crafting recipe.
  */
-public class ConjurejRecipeSelectMenu {
+public class ConjurerRecipeSelectMenu {
 
     public static void open(Player player) {
         Inventory inv = Bukkit.createInventory(null, 27, "Select Required Recipe");
 
-        List<String> recipes = ConjurejRecipeUnlockManager.getAllRecipes();
+        List<String> recipes = ConjurerRecipeUnlockManager.getAllRecipes();
         int index = 0;
         for (String recipe : recipes) {
             ItemStack item = new ItemStack(Material.PAPER);

--- a/src/main/java/com/maks/mycraftingplugin2/ConjurerRecipeUnlockManager.java
+++ b/src/main/java/com/maks/mycraftingplugin2/ConjurerRecipeUnlockManager.java
@@ -7,9 +7,9 @@ import java.sql.*;
 import java.util.*;
 
 /**
- * Manages unlocking and tracking of Conjurej recipes for players.
+ * Manages unlocking and tracking of Conjurer recipes for players.
  */
-public class ConjurejRecipeUnlockManager {
+public class ConjurerRecipeUnlockManager {
 
     private static final List<String> ALL_RECIPES = Arrays.asList(
             "Runic Tether",
@@ -31,7 +31,7 @@ public class ConjurejRecipeUnlockManager {
         if (recipe == null || recipe.isEmpty()) return true;
         try (Connection conn = Main.getConnection();
              PreparedStatement ps = conn.prepareStatement(
-                     "SELECT 1 FROM conjurej_recipes WHERE player_uuid=? AND recipe=?")) {
+                     "SELECT 1 FROM conjurer_recipes WHERE player_uuid=? AND recipe=?")) {
             ps.setString(1, uuid.toString());
             ps.setString(2, recipe);
             try (ResultSet rs = ps.executeQuery()) {
@@ -46,7 +46,7 @@ public class ConjurejRecipeUnlockManager {
     public static void unlockRecipe(Player player, String recipe) {
         try (Connection conn = Main.getConnection();
              PreparedStatement ps = conn.prepareStatement(
-                     "INSERT IGNORE INTO conjurej_recipes (player_uuid, recipe) VALUES (?, ?)")) {
+                     "INSERT IGNORE INTO conjurer_recipes (player_uuid, recipe) VALUES (?, ?)")) {
             ps.setString(1, player.getUniqueId().toString());
             ps.setString(2, recipe);
             ps.executeUpdate();
@@ -60,7 +60,7 @@ public class ConjurejRecipeUnlockManager {
         List<String> locked = new ArrayList<>(ALL_RECIPES);
         try (Connection conn = Main.getConnection();
              PreparedStatement ps = conn.prepareStatement(
-                     "SELECT recipe FROM conjurej_recipes WHERE player_uuid=?")) {
+                     "SELECT recipe FROM conjurer_recipes WHERE player_uuid=?")) {
             ps.setString(1, uuid.toString());
             try (ResultSet rs = ps.executeQuery()) {
                 while (rs.next()) {

--- a/src/main/java/com/maks/mycraftingplugin2/ConjurerShopCommand.java
+++ b/src/main/java/com/maks/mycraftingplugin2/ConjurerShopCommand.java
@@ -7,9 +7,9 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 /**
- * /conjurej_shop - Opens the Conjurej main menu.
+ * /conjurer_shop - Opens the Conjurer main menu.
  */
-public class ConjurejShopCommand implements CommandExecutor {
+public class ConjurerShopCommand implements CommandExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
@@ -23,7 +23,7 @@ public class ConjurejShopCommand implements CommandExecutor {
             player.sendMessage(ChatColor.RED + "You must be at least level 80 to use this command.");
             return true;
         }
-        ConjurejMainMenu.open(player);
+        ConjurerMainMenu.open(player);
         return true;
     }
 }

--- a/src/main/java/com/maks/mycraftingplugin2/EditConjurerShopCommand.java
+++ b/src/main/java/com/maks/mycraftingplugin2/EditConjurerShopCommand.java
@@ -7,9 +7,9 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 /**
- * /edit_conjurej_shop - Opens the Conjurej main menu in edit mode.
+ * /edit_conjurer_shop - Opens the Conjurer main menu in edit mode.
  */
-public class EditConjurejShopCommand implements CommandExecutor {
+public class EditConjurerShopCommand implements CommandExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
@@ -25,7 +25,7 @@ public class EditConjurejShopCommand implements CommandExecutor {
             return true;
         }
 
-        ConjurejMainMenu.openEditor(player);
+        ConjurerMainMenu.openEditor(player);
         return true;
     }
 }

--- a/src/main/java/com/maks/mycraftingplugin2/EditRecipeMenu.java
+++ b/src/main/java/com/maks/mycraftingplugin2/EditRecipeMenu.java
@@ -83,7 +83,7 @@ public class EditRecipeMenu {
                         ));
 
                         String category = rs.getString("category");
-                        if ("conjurej_shop".equalsIgnoreCase(category)) {
+                        if ("conjurer_shop".equalsIgnoreCase(category)) {
                             String required = rs.getString("required_recipe");
                             TemporaryData.setRequiredRecipe(player.getUniqueId(), required);
                             String display = (required != null) ? required : "None";

--- a/src/main/java/com/maks/mycraftingplugin2/Main.java
+++ b/src/main/java/com/maks/mycraftingplugin2/Main.java
@@ -58,13 +58,13 @@ public class Main extends JavaPlugin {
         getCommand("edit_zumpe").setExecutor(new EditZumpeCommand());
         getCommand("testjewels").setExecutor(new TestJewelsCommand());
         getCommand("testpouch").setExecutor(new TestPouchCommand());
-        getCommand("conjurej_shop").setExecutor(new ConjurejShopCommand());
-        getCommand("edit_conjurej_shop").setExecutor(new EditConjurejShopCommand());
+        getCommand("conjurer_shop").setExecutor(new ConjurerShopCommand());
+        getCommand("edit_conjurer_shop").setExecutor(new EditConjurerShopCommand());
 
         // Rejestracja listenerów
         getServer().getPluginManager().registerEvents(new MenuListener(), this);
         getServer().getPluginManager().registerEvents(new ChatListener(), this);
-        getServer().getPluginManager().registerEvents(new ConjurejRecipeDropListener(), this);
+        getServer().getPluginManager().registerEvents(new ConjurerRecipeDropListener(), this);
 
         // Schedule daily transaction cleanup at midnight
         setupTransactionCleanupTask();
@@ -173,14 +173,14 @@ public class Main extends JavaPlugin {
                     getLogger().info("Recipes table update skipped: " + e.getMessage());
                 }
 
-                String createConjurejTable = """
-                    CREATE TABLE IF NOT EXISTS conjurej_recipes (
+                String createConjurerTable = """
+                    CREATE TABLE IF NOT EXISTS conjurer_recipes (
                         player_uuid VARCHAR(36),
                         recipe VARCHAR(255),
                         PRIMARY KEY (player_uuid, recipe)
                     )
                 """;
-                statement.executeUpdate(createConjurejTable);
+                statement.executeUpdate(createConjurerTable);
 
                 // Create Emilia shop tables if they don't exist
                 String createEmiliaItemsTable = """

--- a/src/main/java/com/maks/mycraftingplugin2/MenuListener.java
+++ b/src/main/java/com/maks/mycraftingplugin2/MenuListener.java
@@ -177,12 +177,12 @@ public class MenuListener implements Listener {
             handleRunemasterMenuClick(player, itemName);
         } else if (title.equals("Edit Runemaster Menu")) {
             handleEditRunemasterMenuClick(player, itemName);
-        } else if (title.equals("Conjurej Menu")) {
-            handleConjurejMenuClick(player, itemName);
-        } else if (title.equals("Edit Conjurej Menu")) {
-            handleEditConjurejMenuClick(player, itemName);
+        } else if (title.equals("Conjurer Menu")) {
+            handleConjurerMenuClick(player, itemName);
+        } else if (title.equals("Edit Conjurer Menu")) {
+            handleEditConjurerMenuClick(player, itemName);
         } else if (title.equals("Select Required Recipe")) {
-            handleConjurejRecipeSelectMenu(player, itemName);
+            handleConjurerRecipeSelectMenu(player, itemName);
         } else if (title.equals("Rune Crushing")) {
             handleRuneCrushingMenuClick(event, player, clickedItem, itemName);
         } else if (title.equals("Emilia Shop")) {
@@ -241,8 +241,8 @@ public class MenuListener implements Listener {
                 || title.equals("Runemaster Menu")
                 || title.equals("Edit Runemaster Menu")
                 || title.equals("Rune Crushing")
-                || title.equals("Conjurej Menu")
-                || title.equals("Edit Conjurej Menu")
+                || title.equals("Conjurer Menu")
+                || title.equals("Edit Conjurer Menu")
                 || title.equals("Select Required Recipe")
                 || title.equals("Emilia Shop")
                 || title.equals("Edit Emilia Shop")
@@ -353,10 +353,10 @@ public class MenuListener implements Listener {
                         break;
 
                     case 25:
-                        // Required recipe selector (Conjurej shop)
+                        // Required recipe selector (Conjurer shop)
                         AddRecipeMenu.saveGuiState(player.getUniqueId(), inv.getContents());
                         TemporaryData.setPlayerData(player.getUniqueId(), "edit_menu_title", title);
-                        ConjurejRecipeSelectMenu.open(player);
+                        ConjurerRecipeSelectMenu.open(player);
                         break;
 
                     default:
@@ -497,12 +497,12 @@ public class MenuListener implements Listener {
                         RunemasterMainMenu.open(player);
                     }
                 }
-                // Jeżeli to kategoria Conjurej Shop
-                else if (category.equalsIgnoreCase("conjurej_shop")) {
+                // Jeżeli to kategoria Conjurer Shop
+                else if (category.equalsIgnoreCase("conjurer_shop")) {
                     if (isEditMode) {
-                        MainMenu.openEditor(player);
+                        ConjurerMainMenu.openEditor(player);
                     } else {
-                        MainMenu.open(player);
+                        ConjurerMainMenu.open(player);
                     }
                 }
                 // Jeżeli to kategoria Mine Shop
@@ -599,7 +599,7 @@ public class MenuListener implements Listener {
                     return;
                 }
 
-                if (!isEditMode && "conjurej_shop".equalsIgnoreCase(category)) {
+                if (!isEditMode && "conjurer_shop".equalsIgnoreCase(category)) {
                     try (Connection conn = Main.getConnection();
                          PreparedStatement ps = conn.prepareStatement("SELECT required_recipe FROM recipes WHERE id=?")) {
                         ps.setInt(1, recipeId);
@@ -607,7 +607,7 @@ public class MenuListener implements Listener {
                             if (rs.next()) {
                                 String required = rs.getString("required_recipe");
                                 if (required != null && !required.isEmpty() &&
-                                        !ConjurejRecipeUnlockManager.hasRecipe(player.getUniqueId(), required)) {
+                                        !ConjurerRecipeUnlockManager.hasRecipe(player.getUniqueId(), required)) {
                                     player.sendMessage(ChatColor.RED + "This recipe is locked. Missing recipe: " + required);
 
                                     return;
@@ -712,8 +712,8 @@ public class MenuListener implements Listener {
                 if (rs.next()) {
                     String category = rs.getString("category");
                     String required = rs.getString("required_recipe");
-                    if ("conjurej_shop".equalsIgnoreCase(category) &&
-                            !ConjurejRecipeUnlockManager.hasRecipe(player.getUniqueId(), required)) {
+                    if ("conjurer_shop".equalsIgnoreCase(category) &&
+                            !ConjurerRecipeUnlockManager.hasRecipe(player.getUniqueId(), required)) {
                         player.sendMessage(ChatColor.RED + "You have not unlocked the " + required + " recipe.");
                         return;
                     }
@@ -1098,9 +1098,9 @@ public class MenuListener implements Listener {
             // Koszt
             ps.setDouble(15, TemporaryData.getCost(player.getUniqueId()));
 
-            // Required recipe (only for conjurej shop)
+            // Required recipe (only for conjurer shop)
             String required = TemporaryData.getRequiredRecipe(player.getUniqueId());
-            if (!"conjurej_shop".equalsIgnoreCase(category)) {
+            if (!"conjurer_shop".equalsIgnoreCase(category)) {
                 required = null;
             }
             ps.setString(16, required);
@@ -1164,7 +1164,7 @@ public class MenuListener implements Listener {
 
             String required = TemporaryData.getRequiredRecipe(player.getUniqueId());
             String category = TemporaryData.getLastCategory(player.getUniqueId());
-            if (!"conjurej_shop".equalsIgnoreCase(category)) {
+            if (!"conjurer_shop".equalsIgnoreCase(category)) {
                 required = null;
             }
             ps.setString(14, required);
@@ -1437,12 +1437,12 @@ public class MenuListener implements Listener {
         }
     }
 
-    private void handleConjurejMenuClick(Player player, String itemName) {
+    private void handleConjurerMenuClick(Player player, String itemName) {
         if (itemName == null) return;
 
         switch (itemName) {
-            case "Conjurej Shop":
-                CategoryMenu.open(player, "conjurej_shop", 0);
+            case "Conjurer Shop":
+                CategoryMenu.open(player, "conjurer_shop", 0);
                 break;
             case "Conjuration":
                 player.closeInventory();
@@ -1464,12 +1464,12 @@ public class MenuListener implements Listener {
         }
     }
 
-    private void handleEditConjurejMenuClick(Player player, String itemName) {
+    private void handleEditConjurerMenuClick(Player player, String itemName) {
         if (itemName == null) return;
 
         switch (itemName) {
-            case "Conjurej Shop":
-                CategoryMenu.openEditor(player, "conjurej_shop", 0);
+            case "Conjurer Shop":
+                CategoryMenu.openEditor(player, "conjurer_shop", 0);
                 break;
             case "Conjuration":
                 player.sendMessage(ChatColor.YELLOW + "Conjuration coming soon!");
@@ -1482,7 +1482,7 @@ public class MenuListener implements Listener {
         }
     }
 
-    private void handleConjurejRecipeSelectMenu(Player player, String itemName) {
+    private void handleConjurerRecipeSelectMenu(Player player, String itemName) {
         if (itemName == null) return;
 
         String title = (String) TemporaryData.getPlayerData(player.getUniqueId(), "edit_menu_title");

--- a/src/main/java/com/maks/mycraftingplugin2/TemporaryData.java
+++ b/src/main/java/com/maks/mycraftingplugin2/TemporaryData.java
@@ -68,7 +68,7 @@ public class TemporaryData {
         costs.remove(playerUUID);
     }
 
-    // Required recipe for Conjurej shop crafting
+    // Required recipe for Conjurer shop crafting
     private static Map<UUID, String> requiredRecipes = new HashMap<>();
 
     public static void setRequiredRecipe(UUID playerUUID, String recipe) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -8,7 +8,7 @@ database:
 # Enable debug mode (1 = enabled, 0 = disabled)
 debug: 1
 
-conjurej:
+conjurer:
   mobs: |
     # obstinate_toltec_warrior
     # obstinate_toltec_hunter

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -90,13 +90,13 @@ commands:
     description: "Opens Zumpe shop menu in edit mode"
     usage: /edit_zumpe
     permission: mycraftingplugin.editlayout
-  conjurej_shop:
-    description: "Opens the Conjurej menu"
-    usage: /conjurej_shop
+  conjurer_shop:
+    description: "Opens the Conjurer menu"
+    usage: /conjurer_shop
     permission: mycraftingplugin.use
-  edit_conjurej_shop:
-    description: "Opens the Conjurej menu in edit mode"
-    usage: /edit_conjurej_shop
+  edit_conjurer_shop:
+    description: "Opens the Conjurer menu in edit mode"
+    usage: /edit_conjurer_shop
     permission: mycraftingplugin.editlayout
   testjewels:
     description: Test jewel detection system


### PR DESCRIPTION
## Summary
- Rename all Conjurej commands, menus, and config keys to Conjurer
- Correct back button in Conjurer shop to return to the Conjurer menu

## Testing
- `mvn -q -e package` *(fails: PluginResolutionException - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a3024aa1d0832a92a2e18e39645502