### PR TITLE
feat: add debug logs for conjurer recipe drops

### DIFF
--- a/src/main/java/com/maks/mycraftingplugin2/ConjurerRecipeDropListener.java
+++ b/src/main/java/com/maks/mycraftingplugin2/ConjurerRecipeDropListener.java
@@ -36,23 +36,38 @@ public class ConjurerRecipeDropListener implements Listener {
         } else if (entity.hasMetadata("MythicMob")) {
             mobId = entity.getMetadata("MythicMob").get(0).asString();
         }
-        if (mobId == null) return;
+        if (mobId == null) {
+            Main.getInstance().getLogger().info("Entity killed without MythicMob metadata: " + entity.getType());
+            return;
+        }
+
+        Main.getInstance().getLogger().info("Mythic mob killed: " + mobId);
 
         List<String> allowed = Main.getInstance().getConfig()
                 .getStringList("conjurer.mobs").stream()
                 .map(s -> s.replace(",", "").trim().toLowerCase(Locale.ROOT))
                 .filter(s -> !s.isEmpty())
                 .collect(Collectors.toList());
-        if (!allowed.contains(mobId.toLowerCase(Locale.ROOT))) return;
+        boolean isAllowed = allowed.contains(mobId.toLowerCase(Locale.ROOT));
+        Main.getInstance().getLogger().info("Mob in conjurer list: " + isAllowed);
+        if (!isAllowed) return;
 
         double dropChance = Main.getInstance().getConfig().getDouble("conjurer.recipe_drop_chance", 0.001);
-        if (random.nextDouble() >= dropChance) return;
+        double roll = random.nextDouble();
+        Main.getInstance().getLogger().info("Rolled " + roll + " against drop chance " + dropChance);
+        if (roll >= dropChance) {
+            Main.getInstance().getLogger().info("Roll failed; no recipe drop.");
+            return;
+        }
+
+        Main.getInstance().getLogger().info("Roll succeeded; attempting recipe drop.");
 
         UUID uuid = killer.getUniqueId();
         List<String> locked = ConjurerRecipeUnlockManager.getLockedRecipes(uuid);
         if (locked.isEmpty()) return;
 
         String recipe = locked.get(random.nextInt(locked.size()));
+        Main.getInstance().getLogger().info("Unlocking recipe " + recipe + " for player " + killer.getName());
         ConjurerRecipeUnlockManager.unlockRecipe(killer, recipe);
         killer.sendMessage(ChatColor.AQUA + "You feel knowledge flow through you...");
     }


### PR DESCRIPTION
## Summary
- log MythicMobs entity id on death and whether it's eligible for Conjurer recipe drop
- print rolled drop chance and whether a recipe unlock occurs

## Testing
- `mvn -q -e -ntp test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a317bad5ec832a83d229ae3835b25f