### PR TITLE
Disable UnifiedConfirmation debug logs

### DIFF
--- a/src/main/java/com/maks/mycraftingplugin2/UnifiedConfirmationMenu.java
+++ b/src/main/java/com/maks/mycraftingplugin2/UnifiedConfirmationMenu.java
@@ -19,7 +19,9 @@ import java.util.*;
  */
 public class UnifiedConfirmationMenu {
 
-    private static final int debuggingFlag = 1; // Set to 0 to disable debug messages
+    private static boolean isDebugEnabled() {
+        return Main.getInstance().getConfig().getInt("debug", 0) == 1;
+    }
 
     public enum ShopType {
         CRAFTING("recipes", "recipe_id", "Crafting Scheme"),
@@ -41,7 +43,7 @@ public class UnifiedConfirmationMenu {
      * Opens unified confirmation menu for any shop type
      */
     public static void open(Player player, int itemId, ShopType shopType) {
-        if (debuggingFlag == 1) {
+        if (isDebugEnabled()) {
             Bukkit.getLogger().info("[UnifiedConfirmation] Opening " + shopType.menuTitle + " for itemId: " + itemId);
         }
 
@@ -99,7 +101,7 @@ public class UnifiedConfirmationMenu {
                             ItemStack requiredItem = ItemStackSerializer.deserialize(itemData);
                             inv.setItem(10 + i, requiredItem);
 
-                            if (debuggingFlag == 1) {
+                            if (isDebugEnabled()) {
                                 Bukkit.getLogger().info("[UnifiedConfirmation] Set required item " + (i+1) + " in slot " + (10+i));
                             }
                         }
@@ -145,7 +147,7 @@ public class UnifiedConfirmationMenu {
                         resultItem.setItemMeta(meta);
                     }
 
-                    if (debuggingFlag == 1) {
+                    if (isDebugEnabled()) {
                         Bukkit.getLogger().info("[UnifiedConfirmation] Set result item for " + shopType.name());
                     }
 
@@ -283,7 +285,7 @@ public class UnifiedConfirmationMenu {
      * Updates button state and daily limit display
      */
     public static void refresh(Player player, int itemId, ShopType shopType) {
-        if (debuggingFlag == 1) {
+        if (isDebugEnabled()) {
             Bukkit.getLogger().info("[UnifiedConfirmation] Refreshing menu for " + shopType.name() + ", itemId: " + itemId);
         }
 
@@ -345,8 +347,8 @@ public class UnifiedConfirmationMenu {
 
                 boolean canExchange = usedToday < dailyLimit;
 
-                if (debuggingFlag == 1) {
-                    Bukkit.getLogger().info("[UnifiedConfirmation] Daily limit check: " + 
+                if (isDebugEnabled()) {
+                    Bukkit.getLogger().info("[UnifiedConfirmation] Daily limit check: " +
                                           usedToday + "/" + dailyLimit + " = " + canExchange);
                 }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -6,7 +6,7 @@ database:
   password: ""
 
 # Enable debug mode (1 = enabled, 0 = disabled)
-debug: 1
+debug: 0
 
 conjurer:
   mobs:

--- a/target/classes/config.yml
+++ b/target/classes/config.yml
@@ -6,4 +6,4 @@ database:
   password: ""
 
 # Enable debug mode (1 = enabled, 0 = disabled)
-debug: 1
+debug: 0


### PR DESCRIPTION
## Summary
- Read debug flag from config in `UnifiedConfirmationMenu` and gate log messages
- Default debug configuration set to off

## Testing
- ⚠️ `mvn -q test` *(failed: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a349a6c4c8832aae70b0374e978777