### PR TITLE
Add mapping for new IngredientPouch items

### DIFF
--- a/src/main/java/com/maks/mycraftingplugin2/integration/PouchItemMappings.java
+++ b/src/main/java/com/maks/mycraftingplugin2/integration/PouchItemMappings.java
@@ -2,6 +2,9 @@ package com.maks.mycraftingplugin2.integration;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.HashSet;
+import java.util.Arrays;
+import java.util.Set;
 
 /**
  * Complete mappings between display names and pouch item IDs
@@ -10,6 +13,29 @@ import java.util.Map;
 public class PouchItemMappings {
 
     private static final Map<String, String> itemMappings = new HashMap<>();
+    private static final Set<String> mineItems = new HashSet<>(Arrays.asList(
+        "Hematite",
+        "Black Spinel",
+        "Black Diamond",
+        "Magnetite",
+        "Silver",
+        "Osmium",
+        "Azurite",
+        "Tanzanite",
+        "Blue Sapphire",
+        "Carnelian",
+        "Red Spinel",
+        "Pigeon Blood Ruby",
+        "Pyrite",
+        "Yellow Topaz",
+        "Yellow Sapphire",
+        "Malachite",
+        "Peridot",
+        "Tropiche Emerald",
+        "Danburite",
+        "Goshenite",
+        "Cerussite"
+    ));
 
     static {
         initializeMappings();
@@ -88,6 +114,29 @@ public class PouchItemMappings {
         itemMappings.put("[ II ] Leaf", "leaf_II");
         itemMappings.put("[ III ] Leaf", "leaf_III");
 
+        // MINE category items
+        itemMappings.put("Hematite", "hematite");
+        itemMappings.put("Black Spinel", "black_spinel");
+        itemMappings.put("Black Diamond", "black_diamond");
+        itemMappings.put("Magnetite", "magnetite");
+        itemMappings.put("Silver", "silver");
+        itemMappings.put("Osmium", "osmium");
+        itemMappings.put("Azurite", "azurite");
+        itemMappings.put("Tanzanite", "tanzanite");
+        itemMappings.put("Blue Sapphire", "blue_sapphire");
+        itemMappings.put("Carnelian", "carnelian");
+        itemMappings.put("Red Spinel", "red_spinel");
+        itemMappings.put("Pigeon Blood Ruby", "pigeon_blood_ruby");
+        itemMappings.put("Pyrite", "pyrite");
+        itemMappings.put("Yellow Topaz", "yellow_topaz");
+        itemMappings.put("Yellow Sapphire", "yellow_sapphire");
+        itemMappings.put("Malachite", "malachite");
+        itemMappings.put("Peridot", "peridot");
+        itemMappings.put("Tropiche Emerald", "tropiche_emerald");
+        itemMappings.put("Danburite", "danburite");
+        itemMappings.put("Goshenite", "goshenite");
+        itemMappings.put("Cerussite", "cerussite");
+
         // LOWISKO (fishing) category items - POPRAWIONE ID!
         itemMappings.put("[ I ] Algal", "alga_I");
         itemMappings.put("[ II ] Algal", "alga_II");
@@ -99,6 +148,35 @@ public class PouchItemMappings {
         itemMappings.put("[ II ] Heart of the Ocean", "ocean_heart_II");
         itemMappings.put("[ III ] Heart of the Ocean", "ocean_heart_III");
 
+        // FARMING category items
+        itemMappings.put("[ I ] Plant Fiber", "farmer_plant_fiber_I");
+        itemMappings.put("[ II ] Plant Fiber", "farmer_plant_fiber_II");
+        itemMappings.put("[ III ] Plant Fiber", "farmer_plant_fiber_III");
+        itemMappings.put("[ I ] Seed Pouch", "farmer_seed_pouch_I");
+        itemMappings.put("[ II ] Seed Pouch", "farmer_seed_pouch_II");
+        itemMappings.put("[ III ] Seed Pouch", "farmer_seed_pouch_III");
+        itemMappings.put("[ I ] Compost Dust", "farmer_compost_dust_I");
+        itemMappings.put("[ II ] Compost Dust", "farmer_compost_dust_II");
+        itemMappings.put("[ III ] Compost Dust", "farmer_compost_dust_III");
+        itemMappings.put("[ I ] Herbal Extract", "farmer_herb_extract_I");
+        itemMappings.put("[ II ] Herbal Extract", "farmer_herb_extract_II");
+        itemMappings.put("[ III ] Herbal Extract", "farmer_herb_extract_III");
+        itemMappings.put("[ I ] Mushroom Spores", "farmer_mushroom_spores_I");
+        itemMappings.put("[ II ] Mushroom Spores", "farmer_mushroom_spores_II");
+        itemMappings.put("[ III ] Mushroom Spores", "farmer_mushroom_spores_III");
+        itemMappings.put("[ I ] Beeswax Chunk", "farmer_beeswax_chunk_I");
+        itemMappings.put("[ II ] Beeswax Chunk", "farmer_beeswax_chunk_II");
+        itemMappings.put("[ III ] Beeswax Chunk", "farmer_beeswax_chunk_III");
+        itemMappings.put("[ I ] Druidic Essence", "farmer_druidic_essence_I");
+        itemMappings.put("[ II ] Druidic Essence", "farmer_druidic_essence_II");
+        itemMappings.put("[ III ] Druidic Essence", "farmer_druidic_essence_III");
+        itemMappings.put("[ I ] Golden Truffle", "farmer_golden_truffle_I");
+        itemMappings.put("[ II ] Golden Truffle", "farmer_golden_truffle_II");
+        itemMappings.put("[ III ] Golden Truffle", "farmer_golden_truffle_III");
+        itemMappings.put("[ I ] Ancient Grain Sheaf", "farmer_ancient_grain_I");
+        itemMappings.put("[ II ] Ancient Grain Sheaf", "farmer_ancient_grain_II");
+        itemMappings.put("[ III ] Ancient Grain Sheaf", "farmer_ancient_grain_III");
+
         // CURRENCY category items
         itemMappings.put("DrakenMelon", "draken");
         itemMappings.put("Glided Sunflower", "clover");
@@ -107,6 +185,7 @@ public class PouchItemMappings {
         itemMappings.put("Jewel Dust", "jewel_dust");
         itemMappings.put("Shiny Dust", "shiny_dust");
         itemMappings.put("Rune Dust", "rune_dust");
+        itemMappings.put("Crystal", "crystal");
     }
 
     /**
@@ -132,6 +211,14 @@ public class PouchItemMappings {
         }
 
         return null;
+    }
+
+    /**
+     * Check if a display name belongs to the MINE category
+     */
+    public static boolean isMineCategoryItem(String displayName) {
+        displayName = org.bukkit.ChatColor.stripColor(displayName);
+        return mineItems.contains(displayName);
     }
 
     /**


### PR DESCRIPTION
## Summary
- map newly added FARMING items (Plant Fiber, Seed Pouch, Compost Dust, etc.) in `PouchItemMappings`
- retain mapping order by category for consistent lookups

## Testing
- `mvn -q test` *(fails: PluginResolutionException - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a347801254832a9ed6a0cd9987fa20