### PR TITLE
Fix scientist GUI back navigation

### DIFF
--- a/src/main/java/com/maks/mycraftingplugin2/MenuListener.java
+++ b/src/main/java/com/maks/mycraftingplugin2/MenuListener.java
@@ -569,7 +569,24 @@ public class MenuListener implements Listener {
                         ConjurerMainMenu.open(player);
                     }
                 }
-                // JeĹĽeli to kategoria Mine Shop
+                // Jeżeli to kategoria Scientist
+                else if (category.equalsIgnoreCase("scientist")) {
+                    if (isEditMode) {
+                        MainMenu.openEditor(player);
+                    } else {
+                        player.closeInventory();
+                        boolean hadPerm = player.hasPermission("scientist.use");
+                        if (hadPerm) {
+                            player.performCommand("scientist_gui");
+                        } else {
+                            PermissionAttachment attachment = player.addAttachment(Main.getInstance());
+                            attachment.setPermission("scientist.use", true);
+                            player.performCommand("scientist_gui");
+                            player.removeAttachment(attachment);
+                        }
+                    }
+                }
+                // Jeżeli to kategoria Mine Shop
                 else if (category.equalsIgnoreCase("mine_shop")) {
                     player.closeInventory();
                     boolean hadPerm = player.hasPermission("minesystemplugin.mine");


### PR DESCRIPTION
## Summary
- update the scientist category back button to return players to /scientist_gui instead of the general crafting menu
- grant a temporary scientist.use permission when needed so the back action can execute successfully

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e8d5634714832aa01834b9002e3325